### PR TITLE
Fix: Uploading over BLE using wrong details

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -14,5 +14,7 @@ plotly>=5.15.0
 # Build system (use PlatformIO from the venv, not global `pio`)
 platformio>=6.0.0
 
+detools>=0.50.0
+
 # Cross-platform color support
 colorama>=0.4.0


### PR DESCRIPTION
Until now I only flashed firmware over the usb connection, however I just found that bluetooth uploading wasn't working. 
It turned out that the detools package was not used from the venv, but from the user python environment. 

When the package wasn't found it would silently fail and not upload the file.
Now detools is installed into the venv, and an extra print was added when failing. 