### PR TITLE
Feat: Partial display updates, increasing fps to 60

### DIFF
--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -129,7 +129,7 @@
 #define LV_DRAW_BUF_STRIDE_ALIGN                4
 
 /** Align start address of draw_buf addresses to this bytes*/
-#define LV_DRAW_BUF_ALIGN                       8
+#define LV_DRAW_BUF_ALIGN                       32
 
 /** Using matrix for transformations.
  * Requirements:

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -28,7 +28,7 @@
 
 /** Color depth: 1 (I1), 8 (L8), 16 (RGB565), 24 (RGB888), 32 (XRGB8888) */
 #define LV_COLOR_DEPTH 16
-
+// #define LV_COLOR_16_SWAP 1
 /*=========================
    STDLIB WRAPPER SETTINGS
  *=========================*/
@@ -126,10 +126,10 @@
  *========================*/
 
 /** Align stride of all layers and images to this bytes */
-#define LV_DRAW_BUF_STRIDE_ALIGN                1
+#define LV_DRAW_BUF_STRIDE_ALIGN                4
 
 /** Align start address of draw_buf addresses to this bytes*/
-#define LV_DRAW_BUF_ALIGN                       4
+#define LV_DRAW_BUF_ALIGN                       8
 
 /** Using matrix for transformations.
  * Requirements:
@@ -1013,7 +1013,7 @@
 #define LV_USE_SNAPSHOT 0
 
 /** 1: Enable system monitor component */
-#define LV_USE_SYSMON   0
+#define LV_USE_SYSMON   1
 #if LV_USE_SYSMON
     /** Get the idle percentage. E.g. uint32_t my_get_idle(void); */
     #define LV_SYSMON_GET_IDLE lv_os_get_idle_percent

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -28,7 +28,7 @@
 
 /** Color depth: 1 (I1), 8 (L8), 16 (RGB565), 24 (RGB888), 32 (XRGB8888) */
 #define LV_COLOR_DEPTH 16
-// #define LV_COLOR_16_SWAP 1
+#define LV_COLOR_16_SWAP 1
 /*=========================
    STDLIB WRAPPER SETTINGS
  *=========================*/

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -1013,7 +1013,7 @@
 #define LV_USE_SNAPSHOT 0
 
 /** 1: Enable system monitor component */
-#define LV_USE_SYSMON   1
+#define LV_USE_SYSMON   0
 #if LV_USE_SYSMON
     /** Get the idle percentage. E.g. uint32_t my_get_idle(void); */
     #define LV_SYSMON_GET_IDLE lv_os_get_idle_percent

--- a/src/hardware/display_manager.cpp
+++ b/src/hardware/display_manager.cpp
@@ -24,7 +24,7 @@ void DisplayManager::init() {
         return;
     }
     
-    gfx_device->fillScreen(RGB565_RED);
+    gfx_device->fillScreen(RGB565_BLACK);
     
     // Initialize LVGL
     lv_init();

--- a/src/hardware/display_manager.cpp
+++ b/src/hardware/display_manager.cpp
@@ -37,7 +37,7 @@ void DisplayManager::init() {
     buffer_size = screen_width * screen_height * sizeof(u_int16_t);  
 
     draw_buffer = (lv_color_t*)heap_caps_aligned_alloc(
-        LV_DRAW_BUF_ALIGN, buffer_size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+        LV_DRAW_BUF_ALIGN, buffer_size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
     if (!draw_buffer) {
         draw_buffer = (lv_color_t*)heap_caps_aligned_alloc(
         LV_DRAW_BUF_ALIGN, buffer_size, MALLOC_CAP_8BIT);
@@ -77,16 +77,16 @@ void DisplayManager::display_rounder_cb(lv_event_t* e) {
 
 void DisplayManager::display_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
     if (!g_display_manager || !g_display_manager->gfx_device) return;
-
+    
     uint32_t w = lv_area_get_width(area);
     uint32_t h = lv_area_get_height(area);
-
+    
     if (LV_COLOR_16_SWAP){
         g_display_manager->gfx_device->draw16bitBeRGBBitmap(area->x1, area->y1, (uint16_t*)px_map, w, h);
     } else {
         g_display_manager->gfx_device->draw16bitRGBBitmap(area->x1, area->y1, (uint16_t*)px_map, w, h);
     }
-
+    
     lv_display_flush_ready(disp);
 }
 

--- a/src/hardware/display_manager.cpp
+++ b/src/hardware/display_manager.cpp
@@ -1,7 +1,6 @@
 #include "display_manager.h"
 #include "../config/constants.h"
 #include "../config/system_config.h"
-#include "../config/logging.h"
 #include <Arduino.h>
 
 

--- a/src/hardware/display_manager.cpp
+++ b/src/hardware/display_manager.cpp
@@ -65,11 +65,6 @@ void DisplayManager::update() {
     lv_timer_handler();
 }
 
-void DisplayManager::flush() {
-    if (!initialized) return;
-    // gfx_device->flush();
-}
-
 // Update the refresh area to be full width
 // This avoids weird artifacts when partial row updates are used
 void DisplayManager::display_rounder_cb(lv_event_t* e) {

--- a/src/hardware/display_manager.cpp
+++ b/src/hardware/display_manager.cpp
@@ -37,6 +37,10 @@ void DisplayManager::init() {
 
     draw_buffer = (lv_color_t*)heap_caps_aligned_alloc(
         32, buffer_size * sizeof(uint16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!draw_buffer) {
+        draw_buffer = (lv_color_t*)heap_caps_aligned_alloc(
+        32, buffer_size * sizeof(uint16_t), MALLOC_CAP_8BIT);
+    }
 
     lvgl_display = lv_display_create(screen_width, screen_height);
     lv_display_set_flush_cb(lvgl_display, display_flush_cb);
@@ -81,7 +85,11 @@ void DisplayManager::display_flush_cb(lv_display_t* disp, const lv_area_t* area,
     uint32_t w = lv_area_get_width(area);
     uint32_t h = lv_area_get_height(area);
 
-    g_display_manager->gfx_device->draw16bitRGBBitmap(area->x1, area->y1, (uint16_t*)px_map, w, h);
+    if (LV_COLOR_16_SWAP){
+        g_display_manager->gfx_device->draw16bitBeRGBBitmap(area->x1, area->y1, (uint16_t*)px_map, w, h);
+    } else {
+        g_display_manager->gfx_device->draw16bitRGBBitmap(area->x1, area->y1, (uint16_t*)px_map, w, h);
+    }
 
     lv_display_flush_ready(disp);
 }

--- a/src/hardware/display_manager.cpp
+++ b/src/hardware/display_manager.cpp
@@ -32,19 +32,21 @@ void DisplayManager::init() {
     screen_width = gfx_device->width();
     screen_height = gfx_device->height();
 
-    buffer_size = screen_width * screen_height;  // Full screen buffer, but only partial updates used
+    // Full screen buffer, but only partial updates used
+    // RGB565 format (16bit per pixel)
+    buffer_size = screen_width * screen_height * sizeof(u_int16_t);  
 
     draw_buffer = (lv_color_t*)heap_caps_aligned_alloc(
-        32, buffer_size * sizeof(uint16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+        LV_DRAW_BUF_ALIGN, buffer_size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     if (!draw_buffer) {
         draw_buffer = (lv_color_t*)heap_caps_aligned_alloc(
-        32, buffer_size * sizeof(uint16_t), MALLOC_CAP_8BIT);
+        LV_DRAW_BUF_ALIGN, buffer_size, MALLOC_CAP_8BIT);
     }
 
     lvgl_display = lv_display_create(screen_width, screen_height);
     lv_display_set_flush_cb(lvgl_display, display_flush_cb);
     lv_display_set_buffers(lvgl_display, draw_buffer, NULL,
-                          buffer_size * sizeof(u_int16_t) , LV_DISPLAY_RENDER_MODE_PARTIAL);
+                          buffer_size , LV_DISPLAY_RENDER_MODE_PARTIAL);
 
     lv_display_add_event_cb(lvgl_display, display_rounder_cb, LV_EVENT_INVALIDATE_AREA, NULL);
     

--- a/src/hardware/display_manager.cpp
+++ b/src/hardware/display_manager.cpp
@@ -1,6 +1,7 @@
 #include "display_manager.h"
 #include "../config/constants.h"
 #include "../config/system_config.h"
+#include "../config/logging.h"
 #include <Arduino.h>
 
 
@@ -18,33 +19,30 @@ void DisplayManager::init() {
         bus, HW_DISPLAY_RESET_PIN, HW_DISPLAY_ROTATION_DEG, HW_DISPLAY_WIDTH_PX, HW_DISPLAY_HEIGHT_PX,
         HW_DISPLAY_COLOR_ORDER, HW_DISPLAY_OFFSET_X_PX, HW_DISPLAY_IPS_INVERT_X, HW_DISPLAY_IPS_INVERT_Y);
     
-    canvas = new Arduino_Canvas(HW_DISPLAY_WIDTH_PX, HW_DISPLAY_HEIGHT_PX, gfx_device, HW_DISPLAY_OFFSET_X_PX, HW_DISPLAY_OFFSET_Y_PX, HW_DISPLAY_ROTATION_DEG);
+    // canvas = new Arduino_Canvas(HW_DISPLAY_WIDTH_PX, HW_DISPLAY_HEIGHT_PX, gfx_device, HW_DISPLAY_OFFSET_X_PX, HW_DISPLAY_OFFSET_Y_PX, HW_DISPLAY_ROTATION_DEG);
     
-    if (!canvas->begin()) {
+    if (!gfx_device->begin()) {
         return;
     }
     
-    canvas->fillScreen(RGB565_BLACK);
+    gfx_device->fillScreen(RGB565_BLUE);
     
     // Initialize LVGL
     lv_init();
     lv_tick_set_cb(millis_cb);
     
-    screen_width = canvas->width();
-    screen_height = canvas->height();
-    buffer_size = screen_width * 40;
-    
-    draw_buffer = (lv_color_t*)heap_caps_malloc(
-        buffer_size * 2, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-    if (!draw_buffer) {
-        draw_buffer = (lv_color_t*)heap_caps_malloc(
-            buffer_size * 2, MALLOC_CAP_8BIT);
-    }
-    
+    screen_width = gfx_device->width();
+    screen_height = gfx_device->height();
+    // Use smaller buffer for reliable partial rendering
+    buffer_size = screen_width * screen_height;  // 64 rows should be enough for most UI elements
+
+    draw_buffer = (lv_color_t*)heap_caps_aligned_alloc(
+        8, buffer_size * 2, MALLOC_CAP_8BIT);
+
     lvgl_display = lv_display_create(screen_width, screen_height);
     lv_display_set_flush_cb(lvgl_display, display_flush_cb);
-    lv_display_set_buffers(lvgl_display, draw_buffer, NULL, 
-                          buffer_size * 2, LV_DISPLAY_RENDER_MODE_PARTIAL);
+    lv_display_set_buffers(lvgl_display, draw_buffer, NULL,
+                          buffer_size * 2 , LV_DISPLAY_RENDER_MODE_PARTIAL);
     
     // Initialize touch
     touch_driver.init();
@@ -59,23 +57,45 @@ void DisplayManager::update() {
     if (!initialized) return;
     
     touch_driver.update();
-    lv_task_handler();
+    lv_timer_handler();
 }
 
 void DisplayManager::flush() {
     if (!initialized) return;
-    canvas->flush();
+    // gfx_device->flush();
 }
 
+
 void DisplayManager::display_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
-    if (!g_display_manager || !g_display_manager->canvas) return;
-    
+    if (!g_display_manager || !g_display_manager->gfx_device) return;
+
     uint32_t w = lv_area_get_width(area);
     uint32_t h = lv_area_get_height(area);
-    g_display_manager->canvas->draw16bitRGBBitmap(
-        area->x1, area->y1, (uint16_t*)px_map, w, h);
-    
-    lv_disp_flush_ready(disp);
+
+    // Calculate stride based on LVGL's 4-byte alignment (LV_DRAW_BUF_STRIDE_ALIGN = 4)
+    // LVGL aligns stride in bytes, not pixels
+    uint32_t stride_bytes = (w * 2 + 3) & ~3;  // Round width*2 up to next 4-byte boundary
+    uint32_t stride_pixels = stride_bytes / 2;  // Convert back to pixels
+
+    uint16_t* src = (uint16_t*)px_map;
+    Arduino_CO5300* display = static_cast<Arduino_CO5300*>(g_display_manager->gfx_device);
+
+    display->startWrite();
+
+    if (stride_pixels == w || h == 1) {
+        // No padding or single row - use fast path
+        display->setAddrWindow(area->x1, area->y1, w, h);
+        display->writePixels(src, w * h);
+    } else {
+        // Handle stride padding row by row
+        for (uint32_t y = 0; y < h; y++) {
+            display->setAddrWindow(area->x1, area->y1 + y, w, 1);
+            display->writePixels(src + (y * stride_pixels), w);
+        }
+    }
+
+    display->endWrite();
+    lv_display_flush_ready(disp);
 }
 
 void DisplayManager::touchpad_read_cb(lv_indev_t* indev, lv_indev_data_t* data) {

--- a/src/hardware/display_manager.h
+++ b/src/hardware/display_manager.h
@@ -8,11 +8,9 @@ class DisplayManager {
 private:
     Arduino_DataBus* bus;
     Arduino_GFX* gfx_device;
-    Arduino_Canvas* canvas;
     lv_display_t* lvgl_display;
     lv_indev_t* lvgl_input;
     lv_color_t* draw_buffer;
-    lv_color_t* draw_buffer2;
     TouchDriver touch_driver;
     
     uint32_t screen_width;
@@ -33,6 +31,7 @@ public:
     
 private:
     static void display_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map);
+    static void display_rounder_cb(lv_event_t* e);
     static void touchpad_read_cb(lv_indev_t* indev, lv_indev_data_t* data);
     static uint32_t millis_cb();
 };

--- a/src/hardware/display_manager.h
+++ b/src/hardware/display_manager.h
@@ -12,6 +12,7 @@ private:
     lv_display_t* lvgl_display;
     lv_indev_t* lvgl_input;
     lv_color_t* draw_buffer;
+    lv_color_t* draw_buffer2;
     TouchDriver touch_driver;
     
     uint32_t screen_width;

--- a/src/hardware/display_manager.h
+++ b/src/hardware/display_manager.h
@@ -21,7 +21,6 @@ private:
 public:
     void init();
     void update();
-    void flush();
     void set_brightness(float brightness);
     
     uint32_t get_width() const { return screen_width; }

--- a/src/tasks/task_manager.cpp
+++ b/src/tasks/task_manager.cpp
@@ -430,10 +430,9 @@ void TaskManager::ui_render_task_impl() {
             ui_manager->update();
         }
         
-        // LVGL processing and display update - this contains lv_task_handler()
+        // LVGL processing and display update - this contains lv_timer_handler()
         if (hardware_manager) {
             hardware_manager->get_display()->update();
-            hardware_manager->get_display()->flush();
         }
         
         uint32_t end_time = millis();

--- a/src/ui/screens/settings_screen.cpp
+++ b/src/ui/screens/settings_screen.cpp
@@ -565,7 +565,7 @@ void SettingsScreen::refresh_statistics() {
     lv_label_set_text(measurements_label, "Measurements: Loading...");
     
     // Force a UI update to show loading text
-    lv_task_handler();
+    lv_timer_handler();
     
     // Perform the expensive IO operations
     uint32_t session_count = grind_logger.get_total_flash_sessions();


### PR DESCRIPTION
Removes the Arduino GFX Canvas, thus allowing us to only partially update the screen instead of the whole thing every time. 
This means that we now only push pixels that have actually changed to the display, improving our fps from a max of 32 to about 60 as defined by the `USER_UI_NORMAL_UPDATE_INTERVAL_MS` variable. When in animation fps goes from below 20 to about 30 as lvgl also needs time to render.

One thing of note is that CO5300 driver had some weird artifacts when only updating a part of the screen. Vertical lines would appear to the left and right of recently updated objects. This was mitigated by setting the update window to the full row, thus leaving some extra room for improvements.

