### PR TITLE
Feat: Updated UI screens to use shared UI elements

### DIFF
--- a/src/config/hardware_config.h
+++ b/src/config/hardware_config.h
@@ -83,7 +83,7 @@
 #define HW_DISPLAY_IPS_INVERT_X 180                                            // IPS X-axis inversion setting
 #define HW_DISPLAY_IPS_INVERT_Y 24                                             // IPS Y-axis inversion setting
 #define HW_DISPLAY_COLOR_ORDER 20                                              // Color channel ordering
-
+#define HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT 15                                       // Minimum brightness percentage (to avoid too dim to see)
 //------------------------------------------------------------------------------
 // SERIAL COMMUNICATION
 //------------------------------------------------------------------------------

--- a/src/config/hardware_config.h
+++ b/src/config/hardware_config.h
@@ -37,7 +37,7 @@
 // Load Cell ADC Configuration (HX711 only)
 
 // Mock driver configuration (compile-time selectable)
-#define HW_ENABLE_LOADCELL_MOCK 1                                            // 0=use physical HX711, 1=use simulated mock driver
+#define HW_ENABLE_LOADCELL_MOCK 0                                            // 0=use physical HX711, 1=use simulated mock driver
 #define HW_MOCK_FLOW_RATE_GPS 1.9f                                           // Simulated continuous flow rate in grams per second
 #define HW_MOCK_CAL_FACTOR -7050.0f                                          // Fixed calibration factor used during mocking
 #define HW_MOCK_BASELINE_RAW 0x700000                                        // Baseline raw count around mid-scale for tare offset

--- a/src/config/system_config.h
+++ b/src/config/system_config.h
@@ -123,3 +123,4 @@
 //------------------------------------------------------------------------------
 #define SYS_WEIGHT_DISPLAY_FORMAT "%.1fg"                                      // Weight display format string
 #define SYS_RAW_VALUE_FORMAT "%ld"                                             // Raw load cell value format string
+

--- a/src/config/theme_config.h
+++ b/src/config/theme_config.h
@@ -21,7 +21,7 @@
 // COLOR SCHEME (RGB565 Format)
 //------------------------------------------------------------------------------
 // Primary brand colors
-#define THEME_COLOR_PRIMARY 0xFF0000                                           // Primary theme color (red)
+#define THEME_COLOR_PRIMARY 0xFF3D00                                           // Primary theme color (red)
 #define THEME_COLOR_ACCENT 0x00AAFF                                            // Accent color for highlights (blue)
 #define THEME_COLOR_SECONDARY 0xAAAAAA                                         // Secondary theme color (light gray)
 
@@ -52,7 +52,7 @@
 #define THEME_PROGRESS_ARC_DIAMETER_PX 200                                    // Progress arc diameter
 
 // General layout
-#define THEME_CORNER_RADIUS_PX 12                                             // Standard UI element corner radius
+#define THEME_CORNER_RADIUS_PX 20                                            // Standard UI element corner radius
 
 //------------------------------------------------------------------------------  
 // FONT SIZE HIERARCHY

--- a/src/ui/components/blocking_overlay.cpp
+++ b/src/ui/components/blocking_overlay.cpp
@@ -10,21 +10,38 @@ void BlockingOperationOverlay::init() {
     // Create overlay (initially hidden)
     overlay = lv_obj_create(lv_scr_act());
     lv_obj_set_size(overlay, LV_PCT(100), LV_PCT(100));
-    lv_obj_set_style_bg_color(overlay, lv_color_hex(0x000000), 0);
-    lv_obj_set_style_bg_opa(overlay, LV_OPA_80, 0);
+    lv_obj_set_style_bg_color(overlay, lv_color_hex(THEME_COLOR_BACKGROUND), 0);
+    lv_obj_set_style_bg_opa(overlay, THEME_OPACITY_OVERLAY, 0);
     lv_obj_set_style_border_width(overlay, 0, 0);
     lv_obj_set_style_pad_all(overlay, 0, 0);
     lv_obj_center(overlay);
     
     // Ensure overlay is always on top by moving to foreground
     lv_obj_move_foreground(overlay);
+
+    lv_obj_t* content = lv_obj_create(overlay);
+    lv_obj_set_style_bg_opa(content, LV_OPA_TRANSP, 0);
+    lv_obj_set_size(content, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+    lv_obj_set_style_border_width(content, 0, 0);
+    lv_obj_set_style_pad_all(content, 0, 0);
+    lv_obj_set_style_pad_gap(content, 5, 0);
+    lv_obj_center(content);
+
+    lv_obj_set_layout(content, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(content, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(content, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
     
     // Create main label
-    label = lv_label_create(overlay);
-    lv_obj_set_style_text_font(label, &lv_font_montserrat_36, 0);
+    label = lv_label_create(content);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_32, 0);
     lv_obj_set_style_text_color(label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_center(label);
+
+    lv_obj_t * wait_label = lv_label_create(content);
+    lv_label_set_text(wait_label, "Please Wait...");
+    lv_obj_set_style_text_font(wait_label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(wait_label, lv_color_hex(THEME_COLOR_TEXT_SECONDARY), 0);
+    lv_obj_set_style_text_align(wait_label, LV_TEXT_ALIGN_CENTER, 0);
     
     // Hide initially
     lv_obj_add_flag(overlay, LV_OBJ_FLAG_HIDDEN);
@@ -92,15 +109,15 @@ const char* BlockingOperationOverlay::get_operation_message(BlockingOperation op
     
     switch (op_type) {
         case BlockingOperation::TARING:
-            return "TARING...\nPlease wait";
+            return "TARING";
         case BlockingOperation::CALIBRATING:
-            return "CALIBRATING...\nPlease wait";
+            return "CALIBRATING";
         case BlockingOperation::SETTLING:
-            return "SETTLING...\nPlease wait";
+            return "SETTLING";
         case BlockingOperation::BLE_ENABLING:
-            return "ENABLING BLE...\nPlease wait";
+            return "ENABLING BLUETOOTH";
         default:
-            return "Processing...\nPlease wait";
+            return "PROCESSING";
     }
 }
 

--- a/src/ui/event_handlers.cpp
+++ b/src/ui/event_handlers.cpp
@@ -186,14 +186,14 @@ void SettingsEventHandler::handle_settings_reset() {
     confirmation_ui_manager = ui_manager;
     ui_manager->show_confirmation(
         "FACTORY RESET",
-        "WARNING!\n\n"
-        "This will reset all settings\n"
-        "to factory defaults:\n\n"
+        "This will reset all settings to factory defaults:"
+        "\n\n"
         "• Profile weights\n"
         "• Calibration data\n"
-        "• Grind history\n\n"
+        "• Grind history"
+        "\n\n"
         "This action cannot be undone.",
-        LV_SYMBOL_REFRESH " RESET",
+        "RESET",
         lv_color_hex(THEME_COLOR_ERROR),
         factory_reset_callback
     );
@@ -203,13 +203,10 @@ void SettingsEventHandler::handle_settings_purge() {
     confirmation_ui_manager = ui_manager;
     ui_manager->show_confirmation(
         "PURGE GRIND HISTORY",
-        "WARNING!\n\n"
-        "This will permanently\n"
-        "delete all grind history\n"
-        "data from flash memory.\n\n"
-        "This action cannot\n"
-        "be undone.",
-        LV_SYMBOL_TRASH " PURGE",
+        "This will permanently delete all grind history data from flash memory."
+        "\n\n"
+        "This action cannot be undone.",
+        "PURGE",
         lv_color_hex(THEME_COLOR_ERROR),
         purge_grind_history_callback
     );
@@ -237,12 +234,10 @@ void SettingsEventHandler::handle_settings_motor_test() {
     confirmation_ui_manager = ui_manager;
     ui_manager->show_confirmation(
         "MOTOR TEST",
-        "WARNING!\n\n"
-        "Motor will be engaged\n"
-        "for 1 second.\n\n"
-        "Make sure grinder is\n"
-        "safe to run.",
-        LV_SYMBOL_PLAY " RUN",
+        "Motor will be engaged for 1 second."
+        "\n\n"
+        "Make sure grinder is safe to run.",
+        "RUN",
         lv_color_hex(THEME_COLOR_SUCCESS),
         motor_test_callback
     );

--- a/src/ui/event_handlers.cpp
+++ b/src/ui/event_handlers.cpp
@@ -343,14 +343,17 @@ void SettingsEventHandler::handle_brightness_normal_slider() {
     if (!slider) return;
     
     int brightness_percent = lv_slider_get_value(slider);
-    if (brightness_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT) brightness_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
+    if (brightness_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT){
+        brightness_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
+        lv_slider_set_value(slider, brightness_percent, LV_ANIM_OFF);
+    } 
     float brightness = brightness_percent / 100.0f;
     
     // Apply brightness immediately for reactive feedback
     ui_manager->hardware_manager->get_display()->set_brightness(brightness);
     
     // Update label
-    ui_manager->settings_screen.update_brightness_labels();
+    ui_manager->settings_screen.update_brightness_labels(brightness_percent, -1);
     // Do not persist on move; commit on release only
     DEBUG_PRINTF("Normal brightness set to %d%% (%.2f)\n", brightness_percent, brightness);
 }
@@ -362,7 +365,10 @@ void SettingsEventHandler::handle_brightness_normal_slider_released() {
     if (!slider) return;
     
     int brightness_percent = lv_slider_get_value(slider);
-    if (brightness_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT) brightness_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
+    if (brightness_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT) {
+        brightness_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
+        lv_slider_set_value(slider, brightness_percent, LV_ANIM_OFF);
+    }
     float brightness = brightness_percent / 100.0f;
     
     // Persist on release only
@@ -379,14 +385,17 @@ void SettingsEventHandler::handle_brightness_screensaver_slider() {
     if (!slider) return;
     
     int brightness_percent = lv_slider_get_value(slider);
-    if (brightness_percent < 15) brightness_percent = 15;
+    if (brightness_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT) {
+        brightness_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
+        lv_slider_set_value(slider, brightness_percent, LV_ANIM_OFF);
+    }
     float brightness = brightness_percent / 100.0f;
     
     // Apply screensaver brightness for preview during sliding
     ui_manager->hardware_manager->get_display()->set_brightness(brightness);
     
     // Update label
-    ui_manager->settings_screen.update_brightness_labels();
+    ui_manager->settings_screen.update_brightness_labels(-1, brightness_percent);
     
     // Do not persist on move; commit on release only
     DEBUG_PRINTF("Screensaver brightness set to %d%% (%.2f)\n", brightness_percent, brightness);
@@ -399,7 +408,10 @@ void SettingsEventHandler::handle_brightness_screensaver_slider_released() {
     lv_obj_t* slider = ui_manager->settings_screen.get_brightness_screensaver_slider();
     if (slider) {
         int brightness_percent = lv_slider_get_value(slider);
-    if (brightness_percent < 15) brightness_percent = 15;
+        if (brightness_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT) {
+            brightness_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
+            lv_slider_set_value(slider, brightness_percent, LV_ANIM_OFF);
+        }
         float brightness = brightness_percent / 100.0f;
         Preferences prefs;
         prefs.begin("brightness", false);

--- a/src/ui/event_handlers.cpp
+++ b/src/ui/event_handlers.cpp
@@ -4,6 +4,7 @@
 #include "../config/system_config.h"
 #include "../config/logging.h"
 #include "../controllers/grind_mode_traits.h"
+#include "../config/hardware_config.h"
 #include "components/ui_operations.h"
 #include "components/blocking_overlay.h"
 #include "screens/calibration_screen.h"
@@ -342,6 +343,7 @@ void SettingsEventHandler::handle_brightness_normal_slider() {
     if (!slider) return;
     
     int brightness_percent = lv_slider_get_value(slider);
+    if (brightness_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT) brightness_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
     float brightness = brightness_percent / 100.0f;
     
     // Apply brightness immediately for reactive feedback
@@ -360,6 +362,7 @@ void SettingsEventHandler::handle_brightness_normal_slider_released() {
     if (!slider) return;
     
     int brightness_percent = lv_slider_get_value(slider);
+    if (brightness_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT) brightness_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
     float brightness = brightness_percent / 100.0f;
     
     // Persist on release only
@@ -376,6 +379,7 @@ void SettingsEventHandler::handle_brightness_screensaver_slider() {
     if (!slider) return;
     
     int brightness_percent = lv_slider_get_value(slider);
+    if (brightness_percent < 15) brightness_percent = 15;
     float brightness = brightness_percent / 100.0f;
     
     // Apply screensaver brightness for preview during sliding
@@ -395,6 +399,7 @@ void SettingsEventHandler::handle_brightness_screensaver_slider_released() {
     lv_obj_t* slider = ui_manager->settings_screen.get_brightness_screensaver_slider();
     if (slider) {
         int brightness_percent = lv_slider_get_value(slider);
+    if (brightness_percent < 15) brightness_percent = 15;
         float brightness = brightness_percent / 100.0f;
         Preferences prefs;
         prefs.begin("brightness", false);

--- a/src/ui/screens/calibration_screen.cpp
+++ b/src/ui/screens/calibration_screen.cpp
@@ -46,46 +46,6 @@ void CalibrationScreen::create() {
     lv_obj_set_size(weight_input, 1, 1);
     lv_obj_add_flag(weight_input, LV_OBJ_FLAG_HIDDEN);
 
-    // Taring overlay (initially hidden)
-    taring_overlay = lv_obj_create(screen);
-    lv_obj_set_size(taring_overlay, LV_PCT(100), LV_PCT(100));
-    lv_obj_align(taring_overlay, LV_ALIGN_CENTER, 0, 0);
-    lv_obj_set_style_bg_color(taring_overlay, lv_color_hex(0x000000), 0);
-    lv_obj_set_style_bg_opa(taring_overlay, LV_OPA_70, 0);
-    lv_obj_set_style_border_width(taring_overlay, 0, 0);
-    lv_obj_set_style_pad_all(taring_overlay, 0, 0);
-    
-    // Taring label
-    taring_label = lv_label_create(taring_overlay);
-    lv_label_set_text(taring_label, "TARING...\nPlease wait");
-    lv_obj_set_style_text_font(taring_label, &lv_font_montserrat_36, 0);
-    lv_obj_set_style_text_color(taring_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_style_text_align(taring_label, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_align(taring_label, LV_ALIGN_CENTER, 0, 0);
-    
-    // Hide the overlay initially
-    lv_obj_add_flag(taring_overlay, LV_OBJ_FLAG_HIDDEN);
-
-    // Calibrating overlay (initially hidden)
-    calibrating_overlay = lv_obj_create(screen);
-    lv_obj_set_size(calibrating_overlay, LV_PCT(100), LV_PCT(100));
-    lv_obj_align(calibrating_overlay, LV_ALIGN_CENTER, 0, 0);
-    lv_obj_set_style_bg_color(calibrating_overlay, lv_color_hex(0x000000), 0);
-    lv_obj_set_style_bg_opa(calibrating_overlay, LV_OPA_70, 0);
-    lv_obj_set_style_border_width(calibrating_overlay, 0, 0);
-    lv_obj_set_style_pad_all(calibrating_overlay, 0, 0);
-    
-    // Calibrating label
-    calibrating_label = lv_label_create(calibrating_overlay);
-    lv_label_set_text(calibrating_label, "CALIBRATING...\nPlease wait");
-    lv_obj_set_style_text_font(calibrating_label, &lv_font_montserrat_36, 0);
-    lv_obj_set_style_text_color(calibrating_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_style_text_align(calibrating_label, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_align(calibrating_label, LV_ALIGN_CENTER, 0, 0);
-    
-    // Hide the overlay initially
-    lv_obj_add_flag(calibrating_overlay, LV_OBJ_FLAG_HIDDEN);
-
     current_step = CAL_STEP_EMPTY;
     calibration_weight = 20.0f; // Default calibration weight
     visible = false;
@@ -162,20 +122,4 @@ void CalibrationScreen::update_calibration_weight(float weight) {
         snprintf(weight_display, sizeof(weight_display), SYS_WEIGHT_DISPLAY_FORMAT, weight);
         lv_label_set_text(weight_label, weight_display);
     }
-}
-
-void CalibrationScreen::show_taring_overlay() {
-    lv_obj_clear_flag(taring_overlay, LV_OBJ_FLAG_HIDDEN);
-}
-
-void CalibrationScreen::hide_taring_overlay() {
-    lv_obj_add_flag(taring_overlay, LV_OBJ_FLAG_HIDDEN);
-}
-
-void CalibrationScreen::show_calibrating_overlay() {
-    lv_obj_clear_flag(calibrating_overlay, LV_OBJ_FLAG_HIDDEN);
-}
-
-void CalibrationScreen::hide_calibrating_overlay() {
-    lv_obj_add_flag(calibrating_overlay, LV_OBJ_FLAG_HIDDEN);
 }

--- a/src/ui/screens/calibration_screen.cpp
+++ b/src/ui/screens/calibration_screen.cpp
@@ -1,6 +1,7 @@
 #include "calibration_screen.h"
 #include <Arduino.h>
 #include "../../config/constants.h"
+#include "ui_helpers.h"
 
 void CalibrationScreen::create() {
     screen = lv_obj_create(lv_scr_act());
@@ -9,30 +10,9 @@ void CalibrationScreen::create() {
     lv_obj_set_style_bg_opa(screen, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(screen, 0, 0);
     lv_obj_set_style_pad_all(screen, 0, 0);
+    lv_obj_set_style_pad_ver(screen, 6, 0);
 
-    // OK button (top left) - using same size as edit screen
-    ok_button = lv_btn_create(screen);
-    lv_obj_set_size(ok_button, THEME_BUTTON_WIDTH_PX, 75);
-    lv_obj_align(ok_button, LV_ALIGN_TOP_LEFT, 10, 10);
-    lv_obj_set_style_bg_color(ok_button, lv_color_hex(THEME_COLOR_SUCCESS), 0);
-    lv_obj_set_style_border_width(ok_button, 0, 0);
-    
-    lv_obj_t* ok_label = lv_label_create(ok_button);
-    lv_label_set_text(ok_label, LV_SYMBOL_OK);
-    lv_obj_set_style_text_font(ok_label, &lv_font_montserrat_32, 0);
-    lv_obj_center(ok_label);
-
-    // Cancel button (top right)
-    cancel_button = lv_btn_create(screen);
-    lv_obj_set_size(cancel_button, THEME_BUTTON_WIDTH_PX, 75);
-    lv_obj_align(cancel_button, LV_ALIGN_TOP_RIGHT, -10, 10);
-    lv_obj_set_style_bg_color(cancel_button, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(cancel_button, 0, 0);
-    
-    lv_obj_t* cancel_label = lv_label_create(cancel_button);
-    lv_label_set_text(cancel_label, LV_SYMBOL_CLOSE);
-    lv_obj_set_style_text_font(cancel_label, &lv_font_montserrat_32, 0);
-    lv_obj_center(cancel_label);
+    top_button_row = create_dual_button_row(screen, &ok_button, &cancel_button, LV_SYMBOL_OK, LV_SYMBOL_CLOSE, lv_color_hex(THEME_COLOR_SUCCESS), lv_color_hex(THEME_COLOR_NEUTRAL), 80, &lv_font_montserrat_32);
 
     // Title label (center top)
     title_label = lv_label_create(screen);
@@ -56,30 +36,9 @@ void CalibrationScreen::create() {
     lv_obj_set_style_text_color(weight_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
     lv_obj_align(weight_label, LV_ALIGN_CENTER, 0, 55);
 
-    // Minus button (bottom left) - only visible during weight input step
-    minus_btn = lv_btn_create(screen);
-    lv_obj_set_size(minus_btn, THEME_BUTTON_WIDTH_PX, THEME_BUTTON_HEIGHT_PX);
-    lv_obj_align(minus_btn, LV_ALIGN_BOTTOM_LEFT, 10, -5);
-    lv_obj_set_style_bg_color(minus_btn, lv_color_hex(THEME_COLOR_ERROR), 0);
-    lv_obj_set_style_border_width(minus_btn, 0, 0);
-    
-    lv_obj_t* minus_label = lv_label_create(minus_btn);
-    lv_label_set_text(minus_label, LV_SYMBOL_MINUS);
-    lv_obj_set_style_text_font(minus_label, &lv_font_montserrat_32, 0);
-    lv_obj_center(minus_label);
+    lv_obj_t* bottom_button_row = create_dual_button_row(screen, &minus_btn, &plus_btn, LV_SYMBOL_MINUS, LV_SYMBOL_PLUS, lv_color_hex(THEME_COLOR_PRIMARY), lv_color_hex(THEME_COLOR_PRIMARY), 100, &lv_font_montserrat_32);
+    lv_obj_align(bottom_button_row, LV_ALIGN_BOTTOM_MID, 0, 0);
     lv_obj_add_flag(minus_btn, LV_OBJ_FLAG_HIDDEN);
-
-    // Plus button (bottom right) - only visible during weight input step
-    plus_btn = lv_btn_create(screen);
-    lv_obj_set_size(plus_btn, THEME_BUTTON_WIDTH_PX, THEME_BUTTON_HEIGHT_PX);
-    lv_obj_align(plus_btn, LV_ALIGN_BOTTOM_RIGHT, -10, -5);
-    lv_obj_set_style_bg_color(plus_btn, lv_color_hex(THEME_COLOR_ERROR), 0);
-    lv_obj_set_style_border_width(plus_btn, 0, 0);
-    
-    lv_obj_t* plus_label = lv_label_create(plus_btn);
-    lv_label_set_text(plus_label, LV_SYMBOL_PLUS);
-    lv_obj_set_style_text_font(plus_label, &lv_font_montserrat_32, 0);
-    lv_obj_center(plus_label);
     lv_obj_add_flag(plus_btn, LV_OBJ_FLAG_HIDDEN);
 
     // Hidden weight input (keeping for compatibility but not used in UI)
@@ -149,6 +108,7 @@ void CalibrationScreen::set_step(CalibrationStep step) {
     switch (step) {
         case CAL_STEP_EMPTY:
             lv_label_set_text(instruction_label, "Remove all weight\nPress OK when empty");
+            lv_obj_set_style_pad_hor(top_button_row, 0, 0);
             lv_obj_clear_flag(cancel_button, LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(plus_btn, LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(minus_btn, LV_OBJ_FLAG_HIDDEN);
@@ -164,6 +124,7 @@ void CalibrationScreen::set_step(CalibrationStep step) {
             
         case CAL_STEP_COMPLETE:
             lv_label_set_text(instruction_label, "Calibration complete!");
+            lv_obj_set_style_pad_hor(top_button_row, 10, 0);
             lv_obj_add_flag(cancel_button, LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(plus_btn, LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(minus_btn, LV_OBJ_FLAG_HIDDEN);

--- a/src/ui/screens/calibration_screen.h
+++ b/src/ui/screens/calibration_screen.h
@@ -20,10 +20,6 @@ private:
     lv_obj_t* minus_btn;
     lv_obj_t* weight_input;
     lv_obj_t* top_button_row;
-    lv_obj_t* taring_overlay;
-    lv_obj_t* taring_label;
-    lv_obj_t* calibrating_overlay;
-    lv_obj_t* calibrating_label;
     CalibrationStep current_step;
     float calibration_weight;
     bool visible;
@@ -35,10 +31,6 @@ public:
     void set_step(CalibrationStep step);
     void update_current_weight(float weight);
     void update_calibration_weight(float weight);
-    void show_taring_overlay();
-    void hide_taring_overlay();
-    void show_calibrating_overlay();
-    void hide_calibrating_overlay();
     
     bool is_visible() const { return visible; }
     CalibrationStep get_step() const { return current_step; }

--- a/src/ui/screens/calibration_screen.h
+++ b/src/ui/screens/calibration_screen.h
@@ -19,6 +19,7 @@ private:
     lv_obj_t* plus_btn;
     lv_obj_t* minus_btn;
     lv_obj_t* weight_input;
+    lv_obj_t* top_button_row;
     lv_obj_t* taring_overlay;
     lv_obj_t* taring_label;
     lv_obj_t* calibrating_overlay;

--- a/src/ui/screens/confirm_screen.cpp
+++ b/src/ui/screens/confirm_screen.cpp
@@ -8,8 +8,8 @@ void ConfirmScreen::create() {
     lv_obj_align(screen, LV_ALIGN_TOP_MID, 0, 0);
     lv_obj_set_style_bg_opa(screen, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(screen, 0, 0);
-    lv_obj_set_style_pad_ver(screen, 0, 0);
-    lv_obj_set_style_pad_hor(screen, 6, 0);
+    lv_obj_set_style_pad_ver(screen, 6, 0);
+    lv_obj_set_style_pad_hor(screen, 0, 0);
     lv_obj_set_style_pad_gap(screen, 5, 0);
     
     // Set up flex layout (column)
@@ -49,28 +49,9 @@ void ConfirmScreen::create() {
     lv_obj_update_layout(message_container);
     lv_obj_scroll_to_y(message_container, 0, LV_ANIM_OFF);  // Scroll to top
 
-    lv_obj_t *button_container = lv_obj_create(screen);
-    lv_obj_set_size(button_container, LV_PCT(100), 80);
-    lv_obj_set_style_bg_opa(button_container, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_width(button_container, 0, 0);
-    lv_obj_set_style_pad_all(button_container, 0, 0);
-    lv_obj_set_flex_grow(button_container, 0);
-    
-    // Set up button container as horizontal flex
-    lv_obj_set_layout(button_container, LV_LAYOUT_FLEX);
-    lv_obj_set_flex_flow(button_container, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(button_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_gap(button_container, 10, 0);
-    
-    // Buttons
-    confirm_button = create_button(button_container, "Confirm", lv_color_hex(THEME_COLOR_SUCCESS), -1);
+    create_dual_button_row(screen, &confirm_button, &cancel_button, "Confirm", "Cancel", lv_color_hex(THEME_COLOR_SUCCESS));
     confirm_button_label = lv_obj_get_child(confirm_button, -1);
-
-    lv_obj_set_flex_grow(confirm_button, 1);
-    
-    cancel_button = create_button(button_container, "Cancel", lv_color_hex(THEME_COLOR_NEUTRAL), -1);
     cancel_button_label = lv_obj_get_child(cancel_button, -1);
-    lv_obj_set_flex_grow(cancel_button, 1);
     
     visible = false;
     lv_obj_add_flag(screen, LV_OBJ_FLAG_HIDDEN);

--- a/src/ui/screens/confirm_screen.cpp
+++ b/src/ui/screens/confirm_screen.cpp
@@ -1,5 +1,6 @@
 #include "confirm_screen.h"
 #include <Arduino.h>
+#include "ui_helpers.h"
 
 void ConfirmScreen::create() {
       screen = lv_obj_create(lv_scr_act());
@@ -7,8 +8,9 @@ void ConfirmScreen::create() {
     lv_obj_align(screen, LV_ALIGN_TOP_MID, 0, 0);
     lv_obj_set_style_bg_opa(screen, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(screen, 0, 0);
-    lv_obj_set_style_pad_all(screen, 0, 0);
-    lv_obj_set_style_pad_gap(screen, 10, 0);
+    lv_obj_set_style_pad_ver(screen, 0, 0);
+    lv_obj_set_style_pad_hor(screen, 6, 0);
+    lv_obj_set_style_pad_gap(screen, 5, 0);
     
     // Set up flex layout (column)
     lv_obj_set_layout(screen, LV_LAYOUT_FLEX);

--- a/src/ui/screens/confirm_screen.cpp
+++ b/src/ui/screens/confirm_screen.cpp
@@ -3,7 +3,7 @@
 #include "ui_helpers.h"
 
 void ConfirmScreen::create() {
-      screen = lv_obj_create(lv_scr_act());
+    screen = lv_obj_create(lv_scr_act());
     lv_obj_set_size(screen, LV_PCT(100), LV_PCT(100));
     lv_obj_align(screen, LV_ALIGN_TOP_MID, 0, 0);
     lv_obj_set_style_bg_opa(screen, LV_OPA_TRANSP, 0);

--- a/src/ui/screens/confirm_screen.cpp
+++ b/src/ui/screens/confirm_screen.cpp
@@ -2,46 +2,74 @@
 #include <Arduino.h>
 
 void ConfirmScreen::create() {
-    screen = lv_obj_create(lv_scr_act());
+      screen = lv_obj_create(lv_scr_act());
     lv_obj_set_size(screen, LV_PCT(100), LV_PCT(100));
     lv_obj_align(screen, LV_ALIGN_TOP_MID, 0, 0);
     lv_obj_set_style_bg_opa(screen, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(screen, 0, 0);
     lv_obj_set_style_pad_all(screen, 0, 0);
-
+    lv_obj_set_style_pad_gap(screen, 10, 0);
+    
+    // Set up flex layout (column)
+    lv_obj_set_layout(screen, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(screen, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(screen, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    
     // Title label
     title_label = lv_label_create(screen);
-    lv_obj_set_style_text_font(title_label, &lv_font_montserrat_32, 0);  // Smaller font
-    lv_obj_align(title_label, LV_ALIGN_CENTER, 0, -140);  // Move higher
-
-    // Warning/message label
-    warning_label = lv_label_create(screen);
-    lv_obj_set_style_text_font(warning_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(warning_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_style_text_align(warning_label, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_align(warning_label, LV_ALIGN_CENTER, 0, -20);  // Move up slightly
-
-    // Confirm button (bottom left)
-    confirm_button = lv_btn_create(screen);
-    lv_obj_set_size(confirm_button, THEME_BUTTON_WIDTH_PX, CONFIRM_BUTTON_HEIGHT);
-    lv_obj_align(confirm_button, LV_ALIGN_BOTTOM_LEFT, 10, -5);
-    lv_obj_set_style_border_width(confirm_button, 0, 0);
+    lv_obj_set_style_text_font(title_label, &lv_font_montserrat_36, 0);
+    lv_obj_set_style_text_align(title_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_width(title_label, LV_PCT(100));
+    // Title takes only the space it needs
+    lv_obj_set_flex_grow(title_label, 0);
     
-    confirm_button_label = lv_label_create(confirm_button);
-    lv_obj_set_style_text_font(confirm_button_label, &lv_font_montserrat_24, 0);
-    lv_obj_center(confirm_button_label);
+    lv_obj_t *message_container = lv_obj_create(screen);
+    lv_obj_set_width(message_container, LV_PCT(100));
+    lv_obj_set_flex_grow(message_container, 1);
+    lv_obj_set_style_bg_opa(message_container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(message_container, 0, 0);
 
-    // Cancel button (bottom right)
-    cancel_button = lv_btn_create(screen);
-    lv_obj_set_size(cancel_button, THEME_BUTTON_WIDTH_PX, CONFIRM_BUTTON_HEIGHT);
-    lv_obj_align(cancel_button, LV_ALIGN_BOTTOM_RIGHT, -10, -5);
-    lv_obj_set_style_bg_color(cancel_button, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(cancel_button, 0, 0);
+    // Set up container to center content
+    lv_obj_set_layout(message_container, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(message_container, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(message_container, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_add_flag(message_container, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_scroll_dir(message_container, LV_DIR_VER);
+
+    // Create the actual message label inside the container
+    message_label = lv_label_create(message_container);
+    lv_obj_set_style_text_font(message_label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(message_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
+    lv_obj_set_style_text_align(message_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_width(message_label, LV_PCT(100));
+    lv_label_set_long_mode(message_label, LV_LABEL_LONG_WRAP);
+
+    lv_obj_update_layout(message_container);
+    lv_obj_scroll_to_y(message_container, 0, LV_ANIM_OFF);  // Scroll to top
+
+    lv_obj_t *button_container = lv_obj_create(screen);
+    lv_obj_set_size(button_container, LV_PCT(100), 80);
+    lv_obj_set_style_bg_opa(button_container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(button_container, 0, 0);
+    lv_obj_set_style_pad_all(button_container, 0, 0);
+    lv_obj_set_flex_grow(button_container, 0);
     
-    cancel_button_label = lv_label_create(cancel_button);
-    lv_obj_set_style_text_font(cancel_button_label, &lv_font_montserrat_24, 0);
-    lv_obj_center(cancel_button_label);
+    // Set up button container as horizontal flex
+    lv_obj_set_layout(button_container, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(button_container, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(button_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_gap(button_container, 10, 0);
+    
+    // Buttons
+    confirm_button = create_button(button_container, "Confirm", lv_color_hex(THEME_COLOR_SUCCESS), -1);
+    confirm_button_label = lv_obj_get_child(confirm_button, -1);
 
+    lv_obj_set_flex_grow(confirm_button, 1);
+    
+    cancel_button = create_button(button_container, "Cancel", lv_color_hex(THEME_COLOR_NEUTRAL), -1);
+    cancel_button_label = lv_obj_get_child(cancel_button, -1);
+    lv_obj_set_flex_grow(cancel_button, 1);
+    
     visible = false;
     lv_obj_add_flag(screen, LV_OBJ_FLAG_HIDDEN);
 }
@@ -54,7 +82,7 @@ void ConfirmScreen::show(const char* title, const char* message,
     lv_obj_set_style_text_color(title_label, confirm_color, 0);
     
     // Set message
-    lv_label_set_text(warning_label, message);
+    lv_label_set_text(message_label, message);
     
     // Set confirm button
     lv_label_set_text(confirm_button_label, confirm_text);

--- a/src/ui/screens/confirm_screen.h
+++ b/src/ui/screens/confirm_screen.h
@@ -9,7 +9,7 @@ class ConfirmScreen {
 private:
     lv_obj_t* screen;
     lv_obj_t* title_label;
-    lv_obj_t* warning_label;
+    lv_obj_t* message_label;
     lv_obj_t* confirm_button;
     lv_obj_t* cancel_button;
     lv_obj_t* confirm_button_label;

--- a/src/ui/screens/edit_screen.cpp
+++ b/src/ui/screens/edit_screen.cpp
@@ -10,57 +10,20 @@ void EditScreen::create() {
     lv_obj_align(screen, LV_ALIGN_TOP_MID, 0, 0);
     lv_obj_set_style_bg_opa(screen, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(screen, 0, 0);
-    lv_obj_set_style_pad_ver(screen, 0, 0);
-    lv_obj_set_style_pad_hor(screen, 6, 0);
-
+    lv_obj_set_style_pad_ver(screen, 6, 0);
+    lv_obj_set_style_pad_hor(screen, 0, 0);
 
     // Set up flex layout (column)
     lv_obj_set_layout(screen, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(screen, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(screen, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 
-    lv_obj_t *top_button_container = lv_obj_create(screen);
-    lv_obj_set_size(top_button_container, LV_PCT(100), LV_SIZE_CONTENT);
-    lv_obj_set_style_bg_opa(top_button_container, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_width(top_button_container, 0, 0);
-    lv_obj_set_style_pad_all(top_button_container, 0, 0);
-    
-    // Set up button container as horizontal flex
-    lv_obj_set_layout(top_button_container, LV_LAYOUT_FLEX);
-    lv_obj_set_flex_flow(top_button_container, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(top_button_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_gap(top_button_container, 10, 0);
 
-    save_btn = create_button(top_button_container, LV_SYMBOL_OK, lv_color_hex(THEME_COLOR_SUCCESS));
-    lv_obj_set_style_text_font(lv_obj_get_child(save_btn, -1), &lv_font_montserrat_32, 0);
-    lv_obj_set_flex_grow(save_btn, 1);
-
-    cancel_btn = create_button(top_button_container, LV_SYMBOL_CLOSE, lv_color_hex(THEME_COLOR_NEUTRAL));
-    lv_obj_set_style_text_font(lv_obj_get_child(cancel_btn, -1), &lv_font_montserrat_32, 0);
-    lv_obj_set_flex_grow(cancel_btn, 1);
+    create_dual_button_row(screen, &save_btn, &cancel_btn, LV_SYMBOL_OK, LV_SYMBOL_CLOSE, lv_color_hex(THEME_COLOR_SUCCESS), lv_color_hex(THEME_COLOR_NEUTRAL), 80, &lv_font_montserrat_32);
 
     create_profile_label(screen, &profile_label, &weight_label);
 
-    lv_obj_t *bottom_button_container = lv_obj_create(screen);
-    lv_obj_set_size(bottom_button_container, LV_PCT(100), LV_SIZE_CONTENT);
-    lv_obj_set_style_bg_opa(bottom_button_container, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_width(bottom_button_container, 0, 0);
-    lv_obj_set_style_pad_all(bottom_button_container, 0, 0);
-    
-    // Set up button container as horizontal flex
-    lv_obj_set_layout(bottom_button_container, LV_LAYOUT_FLEX);
-    lv_obj_set_flex_flow(bottom_button_container, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(bottom_button_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_gap(bottom_button_container, 10, 0);
-
-    minus_btn = create_button(bottom_button_container, LV_SYMBOL_MINUS, lv_color_hex(THEME_COLOR_PRIMARY), -1);
-    lv_obj_set_style_text_font(lv_obj_get_child(minus_btn, -1), &lv_font_montserrat_32, 0);
-    lv_obj_set_flex_grow(minus_btn, 1);
-
-    plus_btn = create_button(bottom_button_container, LV_SYMBOL_PLUS, lv_color_hex(THEME_COLOR_PRIMARY), -1);
-    lv_obj_set_style_text_font(lv_obj_get_child(plus_btn, -1), &lv_font_montserrat_32, 0);
-    lv_obj_set_flex_grow(plus_btn, 1);
-
+    create_dual_button_row(screen, &minus_btn, &plus_btn, LV_SYMBOL_MINUS, LV_SYMBOL_PLUS, lv_color_hex(THEME_COLOR_PRIMARY), lv_color_hex(THEME_COLOR_PRIMARY), 100, &lv_font_montserrat_32);
 
     visible = false;
     mode = GrindMode::WEIGHT;

--- a/src/ui/screens/edit_screen.cpp
+++ b/src/ui/screens/edit_screen.cpp
@@ -2,6 +2,7 @@
 #include <Arduino.h>
 #include "../../config/constants.h"
 #include "../../controllers/grind_mode_traits.h"
+#include "ui_helpers.h"
 
 void EditScreen::create() {
     screen = lv_obj_create(lv_scr_act());
@@ -9,69 +10,57 @@ void EditScreen::create() {
     lv_obj_align(screen, LV_ALIGN_TOP_MID, 0, 0);
     lv_obj_set_style_bg_opa(screen, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(screen, 0, 0);
-    lv_obj_set_style_pad_all(screen, 0, 0);
+    lv_obj_set_style_pad_ver(screen, 0, 0);
+    lv_obj_set_style_pad_hor(screen, 6, 0);
 
-    // Save button (top left)
-    save_btn = lv_btn_create(screen);
-    lv_obj_set_size(save_btn, THEME_BUTTON_WIDTH_PX, 75);
-    lv_obj_align(save_btn, LV_ALIGN_TOP_LEFT, 10, 10);
-    lv_obj_set_style_bg_color(save_btn, lv_color_hex(THEME_COLOR_SUCCESS), 0);
-    lv_obj_set_style_border_width(save_btn, 0, 0);
+
+    // Set up flex layout (column)
+    lv_obj_set_layout(screen, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(screen, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(screen, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+    lv_obj_t *top_button_container = lv_obj_create(screen);
+    lv_obj_set_size(top_button_container, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(top_button_container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(top_button_container, 0, 0);
+    lv_obj_set_style_pad_all(top_button_container, 0, 0);
     
-    lv_obj_t* save_label = lv_label_create(save_btn);
-    lv_label_set_text(save_label, LV_SYMBOL_OK);
-    lv_obj_set_style_text_font(save_label, &lv_font_montserrat_32, 0);
-    lv_obj_center(save_label);
+    // Set up button container as horizontal flex
+    lv_obj_set_layout(top_button_container, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(top_button_container, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(top_button_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_gap(top_button_container, 10, 0);
 
-    // Cancel button (top right)
-    cancel_btn = lv_btn_create(screen);
-    lv_obj_set_size(cancel_btn, THEME_BUTTON_WIDTH_PX, 75);
-    lv_obj_align(cancel_btn, LV_ALIGN_TOP_RIGHT, -10, 10);
-    lv_obj_set_style_bg_color(cancel_btn, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(cancel_btn, 0, 0);
+    save_btn = create_button(top_button_container, LV_SYMBOL_OK, lv_color_hex(THEME_COLOR_SUCCESS));
+    lv_obj_set_style_text_font(lv_obj_get_child(save_btn, -1), &lv_font_montserrat_32, 0);
+    lv_obj_set_flex_grow(save_btn, 1);
+
+    cancel_btn = create_button(top_button_container, LV_SYMBOL_CLOSE, lv_color_hex(THEME_COLOR_NEUTRAL));
+    lv_obj_set_style_text_font(lv_obj_get_child(cancel_btn, -1), &lv_font_montserrat_32, 0);
+    lv_obj_set_flex_grow(cancel_btn, 1);
+
+    create_profile_label(screen, &profile_label, &weight_label);
+
+    lv_obj_t *bottom_button_container = lv_obj_create(screen);
+    lv_obj_set_size(bottom_button_container, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(bottom_button_container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(bottom_button_container, 0, 0);
+    lv_obj_set_style_pad_all(bottom_button_container, 0, 0);
     
-    lv_obj_t* cancel_label = lv_label_create(cancel_btn);
-    lv_label_set_text(cancel_label, LV_SYMBOL_CLOSE);
-    lv_obj_set_style_text_font(cancel_label, &lv_font_montserrat_32, 0);
-    lv_obj_center(cancel_label);
+    // Set up button container as horizontal flex
+    lv_obj_set_layout(bottom_button_container, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(bottom_button_container, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(bottom_button_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_gap(bottom_button_container, 10, 0);
 
-    // Profile name label (center)
-    profile_label = lv_label_create(screen);
-    lv_label_set_text(profile_label, "DOUBLE");
-    lv_obj_set_style_text_font(profile_label, &lv_font_montserrat_32, 0);
-    lv_obj_set_style_text_color(profile_label, lv_color_hex(THEME_COLOR_SECONDARY), 0);
-    lv_obj_align(profile_label, LV_ALIGN_CENTER, 0, -40);
+    minus_btn = create_button(bottom_button_container, LV_SYMBOL_MINUS, lv_color_hex(THEME_COLOR_PRIMARY), -1);
+    lv_obj_set_style_text_font(lv_obj_get_child(minus_btn, -1), &lv_font_montserrat_32, 0);
+    lv_obj_set_flex_grow(minus_btn, 1);
 
-    // Weight label (center)
-    weight_label = lv_label_create(screen);
-    lv_label_set_text(weight_label, "18.0g");
-    lv_obj_set_style_text_font(weight_label, &lv_font_montserrat_56, 0);
-    lv_obj_set_style_text_color(weight_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_align(weight_label, LV_ALIGN_CENTER, 0, 10);
+    plus_btn = create_button(bottom_button_container, LV_SYMBOL_PLUS, lv_color_hex(THEME_COLOR_PRIMARY), -1);
+    lv_obj_set_style_text_font(lv_obj_get_child(plus_btn, -1), &lv_font_montserrat_32, 0);
+    lv_obj_set_flex_grow(plus_btn, 1);
 
-    // Minus button (bottom left)
-    minus_btn = lv_btn_create(screen);
-    lv_obj_set_size(minus_btn, THEME_BUTTON_WIDTH_PX, THEME_BUTTON_HEIGHT_PX);
-    lv_obj_align(minus_btn, LV_ALIGN_BOTTOM_LEFT, 10, -5);
-    lv_obj_set_style_bg_color(minus_btn, lv_color_hex(THEME_COLOR_ERROR), 0);
-    lv_obj_set_style_border_width(minus_btn, 0, 0);
-    
-    lv_obj_t* minus_label = lv_label_create(minus_btn);
-    lv_label_set_text(minus_label, LV_SYMBOL_MINUS);
-    lv_obj_set_style_text_font(minus_label, &lv_font_montserrat_32, 0);
-    lv_obj_center(minus_label);
-
-    // Plus button (bottom right)
-    plus_btn = lv_btn_create(screen);
-    lv_obj_set_size(plus_btn, THEME_BUTTON_WIDTH_PX, THEME_BUTTON_HEIGHT_PX);
-    lv_obj_align(plus_btn, LV_ALIGN_BOTTOM_RIGHT, -10, -5);
-    lv_obj_set_style_bg_color(plus_btn, lv_color_hex(THEME_COLOR_ERROR), 0);
-    lv_obj_set_style_border_width(plus_btn, 0, 0);
-    
-    lv_obj_t* plus_label = lv_label_create(plus_btn);
-    lv_label_set_text(plus_label, LV_SYMBOL_PLUS);
-    lv_obj_set_style_text_font(plus_label, &lv_font_montserrat_32, 0);
-    lv_obj_center(plus_label);
 
     visible = false;
     mode = GrindMode::WEIGHT;

--- a/src/ui/screens/ready_screen.cpp
+++ b/src/ui/screens/ready_screen.cpp
@@ -2,6 +2,7 @@
 #include <Arduino.h>
 #include "../../config/constants.h"
 #include "../../controllers/grind_mode_traits.h"
+#include "ui_helpers.h"
 
 void ReadyScreen::create() {
     screen = lv_obj_create(lv_scr_act());
@@ -53,22 +54,16 @@ void ReadyScreen::create_profile_page(lv_obj_t* parent, int profile_index, const
     lv_obj_set_layout(parent, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(parent, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(parent, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_gap(parent, 20, 0);
+    lv_obj_set_style_pad_gap(parent, 0, 0);
 
-    // Profile name label
-    lv_obj_t* name_label = lv_label_create(parent);
+    lv_obj_t* name_label;
+    lv_obj_t* profile_container = create_profile_label(parent, &name_label, &weight_labels[profile_index]);
     lv_label_set_text(name_label, profile_name);
-    lv_obj_set_style_text_font(name_label, &lv_font_montserrat_32, 0);
-    lv_obj_set_style_text_color(name_label, lv_color_hex(THEME_COLOR_SECONDARY), 0);
     lv_obj_add_flag(name_label, LV_OBJ_FLAG_CLICKABLE);
-
-    // Weight label
-    weight_labels[profile_index] = lv_label_create(parent);
+    
     char weight_text[16];
     snprintf(weight_text, sizeof(weight_text), SYS_WEIGHT_DISPLAY_FORMAT, weight);
     lv_label_set_text(weight_labels[profile_index], weight_text);
-    lv_obj_set_style_text_font(weight_labels[profile_index], &lv_font_montserrat_60, 0);
-    lv_obj_set_style_text_color(weight_labels[profile_index], lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
     lv_obj_add_flag(weight_labels[profile_index], LV_OBJ_FLAG_CLICKABLE);
 }
 

--- a/src/ui/screens/settings_screen.cpp
+++ b/src/ui/screens/settings_screen.cpp
@@ -275,32 +275,9 @@ void SettingsScreen::create_data_page(lv_obj_t* parent) {
 
     create_toggle_row(parent, "Logging", &logging_toggle);
 
-    // Sessions info (number of recorded grind sessions)
-    sessions_label = lv_label_create(parent);
-    lv_label_set_text(sessions_label, "Sessions: --");
-    lv_obj_set_style_text_font(sessions_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(sessions_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_width(sessions_label, 280);
-    lv_label_set_long_mode(sessions_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(sessions_label, LV_TEXT_ALIGN_LEFT, 0);
-
-    // Events info (total number of events across all sessions)
-    events_label = lv_label_create(parent);
-    lv_label_set_text(events_label, "Events: --");
-    lv_obj_set_style_text_font(events_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(events_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_width(events_label, 280);
-    lv_label_set_long_mode(events_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(events_label, LV_TEXT_ALIGN_LEFT, 0);
-
-    // Measurements info (total number of measurements across all sessions)
-    measurements_label = lv_label_create(parent);
-    lv_label_set_text(measurements_label, "Measurements: --");
-    lv_obj_set_style_text_font(measurements_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(measurements_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_width(measurements_label, 280);
-    lv_label_set_long_mode(measurements_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(measurements_label, LV_TEXT_ALIGN_LEFT, 0);
+    create_data_label(parent, "Sessions:", &sessions_label);
+    create_data_label(parent, "Events:", &events_label);
+    create_data_label(parent, "Measurements:", &measurements_label);
 
     refresh_stats_button = create_button(parent, "Refresh Stats");
     lv_obj_add_flag(refresh_stats_button, LV_OBJ_FLAG_HIDDEN); // Refresh button is not used anymore
@@ -394,35 +371,27 @@ void SettingsScreen::hide_taring_overlay() {
 void SettingsScreen::set_session_count(uint32_t count) {
     if (!sessions_label) return;
     char buf[48];
-    snprintf(buf, sizeof(buf), "Sessions: %lu", (unsigned long)count);
+    snprintf(buf, sizeof(buf), "%lu", (unsigned long)count);
     lv_label_set_text(sessions_label, buf);
 }
 
 void SettingsScreen::set_event_count(uint32_t count) {
     if (!events_label) return;
     char buf[48];
-    snprintf(buf, sizeof(buf), "Events: %lu", (unsigned long)count);
+    snprintf(buf, sizeof(buf), "%lu", (unsigned long)count);
     lv_label_set_text(events_label, buf);
 }
 
 void SettingsScreen::set_measurement_count(uint32_t count) {
     if (!measurements_label) return;
     char buf[48];
-    snprintf(buf, sizeof(buf), "Measurements: %lu", (unsigned long)count);
+    snprintf(buf, sizeof(buf), "%lu", (unsigned long)count);
     lv_label_set_text(measurements_label, buf);
 }
 
 void SettingsScreen::refresh_statistics() {
     if (!visible) return;
-    
-    // Show loading indicators
-    lv_label_set_text(sessions_label, "Sessions: Loading...");
-    lv_label_set_text(events_label, "Events: Loading...");
-    lv_label_set_text(measurements_label, "Measurements: Loading...");
-    
-    // Force a UI update to show loading text
-    lv_timer_handler();
-    
+
     // Perform the expensive IO operations
     uint32_t session_count = grind_logger.get_total_flash_sessions();
     uint32_t event_count = grind_logger.count_total_events_in_flash();
@@ -619,13 +588,31 @@ lv_obj_t* SettingsScreen::create_slider_row(lv_obj_t* parent, const char* text, 
     return row_container;
 }
 
-// lv_obj_t* SettingsScreen::create_data_label(lv_obj_t* parent, const char* text) {
-//     lv_obj_t* label = lv_label_create(parent);
-//     lv_label_set_text(label, text);
-//     lv_obj_set_style_text_font(label, &lv_font_montserrat_24, 0);
-//     lv_obj_set_style_text_color(label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-//     lv_obj_set_width(label, 280);
-//     lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
-//     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
-//     return label;
-// }
+lv_obj_t* SettingsScreen::create_data_label(lv_obj_t* parent, const char* name, lv_obj_t** variable) {
+    lv_obj_t* container = lv_obj_create(parent);
+    lv_obj_set_style_bg_opa(container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(container, 0, 0);
+    lv_obj_set_style_pad_all(container, 2, 0);
+    lv_obj_set_style_pad_left(container, 20, 0);
+    lv_obj_set_style_pad_right(container, 24, 0); // Just a bit away from the scroll bar
+    lv_obj_set_style_margin_all(container, 0, 0);
+    lv_obj_set_size(container, 280, LV_SIZE_CONTENT);
+
+    lv_obj_set_layout(container, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(container, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_flex_align(container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_END);
+    
+    lv_obj_t* label = lv_label_create(container);
+    lv_label_set_text(label, name);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
+    
+    *variable = lv_label_create(container);
+    lv_label_set_text(*variable, "");
+    lv_obj_set_style_text_font(*variable, &lv_font_montserrat_24, 0);
+    // lv_obj_set_flex_grow(*variable, 1);
+    lv_obj_set_style_text_color(*variable, lv_color_hex(THEME_COLOR_TEXT_SECONDARY), 0);
+    lv_obj_set_style_text_align(*variable, LV_TEXT_ALIGN_RIGHT, 0);
+
+    return label;
+}

--- a/src/ui/screens/settings_screen.cpp
+++ b/src/ui/screens/settings_screen.cpp
@@ -451,38 +451,28 @@ void SettingsScreen::update_brightness_sliders() {
     int screensaver_percent = (int)(screensaver_brightness * 100);
     
     // Ensure minimum 15%
-    if (normal_percent < 15) normal_percent = 15;
-    if (screensaver_percent < 15) screensaver_percent = 15;
+    if (normal_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT) normal_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
+    if (screensaver_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT) screensaver_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
     
     // Update sliders
     lv_slider_set_value(brightness_normal_slider, normal_percent, LV_ANIM_OFF);
     lv_slider_set_value(brightness_screensaver_slider, screensaver_percent, LV_ANIM_OFF);
     
-    update_brightness_labels();
+    update_brightness_labels(normal_percent, screensaver_percent);
 }
 
-void SettingsScreen::update_brightness_labels() {
-    if (!brightness_normal_label || !brightness_screensaver_label) return;
+void SettingsScreen::update_brightness_labels(int normal_percent, int screensaver_percent) {
+    if (brightness_normal_label && normal_percent >= 0) {
+        char normal_text[32];
+        snprintf(normal_text, sizeof(normal_text), "Brightness: %d%%", normal_percent);
+        lv_label_set_text(brightness_normal_label, normal_text);
+    }
 
-    int normal_percent = lv_slider_get_value(brightness_normal_slider);
-    if (normal_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT) {
-        normal_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
-        lv_slider_set_value(brightness_normal_slider, HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT, LV_ANIM_OFF);
-    } 
-        
-    int screensaver_percent = lv_slider_get_value(brightness_screensaver_slider);
-    if (screensaver_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT){
-        screensaver_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
-        lv_slider_set_value(brightness_screensaver_slider, HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT, LV_ANIM_OFF);
-    } 
-    char normal_text[32];
-    char screensaver_text[32];
-    
-    snprintf(normal_text, sizeof(normal_text), "Brightness: %d%%", normal_percent);
-    snprintf(screensaver_text, sizeof(screensaver_text), "Dimmed: %d%%", screensaver_percent);
-    
-    lv_label_set_text(brightness_normal_label, normal_text);
-    lv_label_set_text(brightness_screensaver_label, screensaver_text);
+    if (brightness_screensaver_label && screensaver_percent >= 0) {
+        char screensaver_text[32];
+        snprintf(screensaver_text, sizeof(screensaver_text), "Dimmed: %d%%", screensaver_percent);
+        lv_label_set_text(brightness_screensaver_label, screensaver_text);
+    }
 }
 
 lv_obj_t* SettingsScreen::create_separator(lv_obj_t* parent, const char* text) {

--- a/src/ui/screens/settings_screen.cpp
+++ b/src/ui/screens/settings_screen.cpp
@@ -110,29 +110,6 @@ void SettingsScreen::create(BluetoothManager* bluetooth, GrindController* grind_
 
     // Set main page as active (menu will be the landing page)
     lv_menu_set_page(menu, main_page);
-    
-    // Create taring overlay (initially hidden)
-    taring_overlay = lv_obj_create(screen);
-    lv_obj_set_size(taring_overlay, LV_PCT(100), LV_PCT(100));
-    lv_obj_align(taring_overlay, LV_ALIGN_CENTER, 0, 0);
-    lv_obj_set_style_bg_color(taring_overlay, lv_color_hex(0x000000), 0);
-    lv_obj_set_style_bg_opa(taring_overlay, LV_OPA_70, 0);
-    lv_obj_set_style_border_width(taring_overlay, 0, 0);
-    lv_obj_set_style_pad_all(taring_overlay, 0, 0);
-    
-    // Taring label
-    taring_label = lv_label_create(taring_overlay);
-    lv_label_set_text(taring_label, "TARING...\nPlease wait");
-    lv_obj_set_style_text_font(taring_label, &lv_font_montserrat_36, 0);
-    lv_obj_set_style_text_color(taring_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_style_text_align(taring_label, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_align(taring_label, LV_ALIGN_CENTER, 0, 0);
-    
-    // Hide the overlay initially
-    lv_obj_add_flag(taring_overlay, LV_OBJ_FLAG_HIDDEN);
-    
-    // Create back button (common to all pages)
-    // create_back_button();
 
     visible = false;
     lv_obj_add_flag(screen, LV_OBJ_FLAG_HIDDEN);
@@ -316,14 +293,6 @@ void SettingsScreen::update_ble_status() {
         lv_obj_add_flag(ble_status_label, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(ble_timer_label, LV_OBJ_FLAG_HIDDEN);
     }
-}
-
-void SettingsScreen::show_taring_overlay() {
-    lv_obj_clear_flag(taring_overlay, LV_OBJ_FLAG_HIDDEN);
-}
-
-void SettingsScreen::hide_taring_overlay() {
-    lv_obj_add_flag(taring_overlay, LV_OBJ_FLAG_HIDDEN);
 }
 
 void SettingsScreen::refresh_statistics() {

--- a/src/ui/screens/settings_screen.cpp
+++ b/src/ui/screens/settings_screen.cpp
@@ -303,11 +303,12 @@ void SettingsScreen::create_data_page(lv_obj_t* parent) {
     lv_obj_set_style_text_align(measurements_label, LV_TEXT_ALIGN_LEFT, 0);
 
     refresh_stats_button = create_button(parent, "Refresh Stats");
+    lv_obj_add_flag(refresh_stats_button, LV_OBJ_FLAG_HIDDEN); // Refresh button is not used anymore
     // Reset separator
     create_separator(parent, "Reset");
 
     purge_button = create_button(parent, "Purge History", lv_color_hex(THEME_COLOR_WARNING));
-    lv_obj_set_style_margin_bottom(purge_button, 20, 0); 
+    lv_obj_set_style_margin_bottom(purge_button, 10, 0); 
     reset_button = create_button(parent, "Factory Reset", lv_color_hex(THEME_COLOR_ERROR));
 }
 
@@ -485,6 +486,7 @@ lv_obj_t* SettingsScreen::create_separator(lv_obj_t* parent, const char* text) {
     lv_obj_set_layout(separator_container, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(separator_container, LV_FLEX_FLOW_ROW);
     lv_obj_set_flex_align(separator_container, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(separator_container, LV_OBJ_FLAG_SCROLLABLE);
 
     // Create left line
     lv_obj_t* left_line = lv_obj_create(separator_container);
@@ -600,7 +602,7 @@ lv_obj_t* SettingsScreen::create_slider_row(lv_obj_t* parent, const char* text, 
     lv_obj_set_layout(row_container, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(row_container, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(row_container, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_gap(row_container, 20, 0);
+    lv_obj_set_style_pad_gap(row_container, 14, 0);
     lv_obj_set_style_pad_all(row_container, 20, 0);
 
     *label = lv_label_create(row_container);
@@ -613,7 +615,6 @@ lv_obj_t* SettingsScreen::create_slider_row(lv_obj_t* parent, const char* text, 
     lv_obj_set_style_bg_color(*slider, lv_color_hex(THEME_COLOR_BACKGROUND), LV_PART_MAIN);
     lv_obj_set_style_bg_color(*slider, slider_color, LV_PART_INDICATOR);
     lv_obj_set_style_bg_opa(*slider, LV_OPA_TRANSP, LV_PART_KNOB);
-
     
     return row_container;
 }

--- a/src/ui/screens/settings_screen.cpp
+++ b/src/ui/screens/settings_screen.cpp
@@ -3,6 +3,7 @@
 #include "../../config/build_info.h"
 #include "../../config/git_info.h"
 #include "../../config/constants.h"
+#include "../../config/hardware_config.h"
 #include "../../logging/grind_logging.h"
 #include "../../hardware/hardware_manager.h"
 #include "grinding_screen.h"
@@ -89,7 +90,7 @@ void SettingsScreen::create(BluetoothManager* bluetooth, GrindController* grind_
     create_tools_page(tools_tab);
 
     reset_tab = lv_menu_page_create(menu, "Data");
-    create_reset_page(reset_tab);
+    create_data_page(reset_tab);
 
     // Create menu items and link to sub-pages
     lv_obj_t* info_item = create_menu_item(main_page, "System Info");
@@ -212,50 +213,13 @@ void SettingsScreen::create_bluetooth_page(lv_obj_t* parent) {
     lv_obj_set_layout(parent, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(parent, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(parent, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_gap(parent, 15, 0);
-    lv_obj_set_style_pad_top(parent, 20, 0);
 
     // Enable vertical scrolling on the settings page
     lv_obj_set_scroll_dir(parent, LV_DIR_VER);
     lv_obj_set_scrollbar_mode(parent, LV_SCROLLBAR_MODE_AUTO);
 
-    // BLE OTA Toggle
-    lv_obj_t* ble_container = lv_obj_create(parent);
-    lv_obj_set_size(ble_container, 260, 80);
-    lv_obj_set_layout(ble_container, LV_LAYOUT_FLEX);
-    lv_obj_set_flex_flow(ble_container, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(ble_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_bg_color(ble_container, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(ble_container, 0, 0);
-    lv_obj_set_style_radius(ble_container, 8, 0);
-    lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_SCROLLABLE);
-
-    lv_obj_t* ble_label = lv_label_create(ble_container);
-    lv_label_set_text(ble_label, "Enabled");
-    lv_obj_set_style_text_font(ble_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(ble_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-
-    ble_toggle = lv_switch_create(ble_container);
-    lv_obj_set_size(ble_toggle, 100, 60);
-
-    // BLE Startup Toggle
-    lv_obj_t* ble_startup_container = lv_obj_create(parent);
-    lv_obj_set_size(ble_startup_container, 260, 80);
-    lv_obj_set_layout(ble_startup_container, LV_LAYOUT_FLEX);
-    lv_obj_set_flex_flow(ble_startup_container, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(ble_startup_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_bg_color(ble_startup_container, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(ble_startup_container, 0, 0);
-    lv_obj_set_style_radius(ble_startup_container, 8, 0);
-    lv_obj_clear_flag(ble_startup_container, LV_OBJ_FLAG_SCROLLABLE);
-
-    lv_obj_t* ble_startup_label = lv_label_create(ble_startup_container);
-    lv_label_set_text(ble_startup_label, "Startup");
-    lv_obj_set_style_text_font(ble_startup_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(ble_startup_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-
-    ble_startup_toggle = lv_switch_create(ble_startup_container);
-    lv_obj_set_size(ble_startup_toggle, 100, 60);
+    create_toggle_row(parent, "Enabled", &ble_toggle);
+    create_toggle_row(parent, "Startup", &ble_startup_toggle);
 
     // BLE Status label
     ble_status_label = lv_label_create(parent);
@@ -276,64 +240,12 @@ void SettingsScreen::create_display_page(lv_obj_t* parent) {
     lv_obj_set_layout(parent, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(parent, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(parent, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_gap(parent, 15, 0);
-    lv_obj_set_style_pad_top(parent, 20, 0);
-
     // Enable vertical scrolling on the settings page
     lv_obj_set_scroll_dir(parent, LV_DIR_VER);
     lv_obj_set_scrollbar_mode(parent, LV_SCROLLBAR_MODE_AUTO);
 
-    // Normal Brightness Slider
-    lv_obj_t* brightness_normal_container = lv_obj_create(parent);
-    lv_obj_set_size(brightness_normal_container, 260, 104);
-    lv_obj_set_layout(brightness_normal_container, LV_LAYOUT_FLEX);
-    lv_obj_set_flex_flow(brightness_normal_container, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_flex_align(brightness_normal_container, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_bg_color(brightness_normal_container, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(brightness_normal_container, 0, 0);
-    lv_obj_set_style_radius(brightness_normal_container, 8, 0);
-    lv_obj_set_style_pad_all(brightness_normal_container, 10, 0);
-    lv_obj_set_style_pad_gap(brightness_normal_container, 8, 0);
-
-    brightness_normal_label = lv_label_create(brightness_normal_container);
-    lv_label_set_text(brightness_normal_label, "Brightness: 100%");
-    lv_obj_set_style_pad_bottom(brightness_normal_label, 4, 0);
-    lv_obj_set_style_text_font(brightness_normal_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(brightness_normal_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-
-    brightness_normal_slider = lv_slider_create(brightness_normal_container);
-    lv_obj_set_size(brightness_normal_slider, 210, 40);
-    lv_slider_set_range(brightness_normal_slider, 15, 100); // 15% minimum to prevent inoperability
-    lv_slider_set_value(brightness_normal_slider, 100, LV_ANIM_OFF);
-    lv_obj_set_style_bg_color(brightness_normal_slider, lv_color_hex(THEME_COLOR_BACKGROUND), LV_PART_MAIN);
-    lv_obj_set_style_bg_color(brightness_normal_slider, lv_color_hex(THEME_COLOR_ACCENT), LV_PART_INDICATOR);
-    lv_obj_set_style_bg_color(brightness_normal_slider, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), LV_PART_KNOB);
-
-    // Screensaver Brightness Slider
-    lv_obj_t* brightness_screensaver_container = lv_obj_create(parent);
-    lv_obj_set_size(brightness_screensaver_container, 260, 104);
-    lv_obj_set_layout(brightness_screensaver_container, LV_LAYOUT_FLEX);
-    lv_obj_set_flex_flow(brightness_screensaver_container, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_flex_align(brightness_screensaver_container, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_bg_color(brightness_screensaver_container, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(brightness_screensaver_container, 0, 0);
-    lv_obj_set_style_radius(brightness_screensaver_container, 8, 0);
-    lv_obj_set_style_pad_all(brightness_screensaver_container, 10, 0);
-    lv_obj_set_style_pad_gap(brightness_screensaver_container, 8, 0);
-
-    brightness_screensaver_label = lv_label_create(brightness_screensaver_container);
-    lv_label_set_text(brightness_screensaver_label, "Dimmed: 35%");
-    lv_obj_set_style_pad_bottom(brightness_screensaver_label, 4, 0);
-    lv_obj_set_style_text_font(brightness_screensaver_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(brightness_screensaver_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-
-    brightness_screensaver_slider = lv_slider_create(brightness_screensaver_container);
-    lv_obj_set_size(brightness_screensaver_slider, 210, 40);
-    lv_slider_set_range(brightness_screensaver_slider, 15, 100); // 15% minimum to prevent inoperability
-    lv_slider_set_value(brightness_screensaver_slider, 35, LV_ANIM_OFF);
-    lv_obj_set_style_bg_color(brightness_screensaver_slider, lv_color_hex(THEME_COLOR_BACKGROUND), LV_PART_MAIN);
-    lv_obj_set_style_bg_color(brightness_screensaver_slider, lv_color_hex(THEME_COLOR_WARNING), LV_PART_INDICATOR);
-    lv_obj_set_style_bg_color(brightness_screensaver_slider, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), LV_PART_KNOB);
+    create_slider_row(parent, "Brightness", &brightness_normal_label, &brightness_normal_slider);
+    create_slider_row(parent, "Screensaver", &brightness_screensaver_label, &brightness_screensaver_slider, lv_color_hex(THEME_COLOR_WARNING));
 }
 
 void SettingsScreen::create_tools_page(lv_obj_t* parent) {
@@ -346,87 +258,22 @@ void SettingsScreen::create_tools_page(lv_obj_t* parent) {
     lv_obj_clear_flag(parent, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_scrollbar_mode(parent, LV_SCROLLBAR_MODE_OFF);
 
-    // // Title
-    // lv_obj_t* title = lv_label_create(parent);
-    // lv_label_set_text(title, "Tools");
-    // lv_obj_set_style_text_font(title, &lv_font_montserrat_32, 0);
-    // lv_obj_set_style_text_color(title, lv_color_hex(THEME_COLOR_SECONDARY), 0);
-
-    // Tare button
-    tare_button = lv_btn_create(parent);
-    lv_obj_set_size(tare_button, 240, 80);
-    lv_obj_set_style_bg_color(tare_button, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(tare_button, 0, 0);
-    lv_obj_set_style_radius(tare_button, THEME_CORNER_RADIUS_PX, 0);
-    
-    lv_obj_t* tare_label = lv_label_create(tare_button);
-    lv_label_set_text(tare_label, "TARE SCALE");
-    lv_obj_set_style_text_font(tare_label, &lv_font_montserrat_24, 0);
-    lv_obj_center(tare_label);
-
-    // Calibration button
-    cal_button = lv_btn_create(parent);
-    lv_obj_set_size(cal_button, 240, 80);
-    lv_obj_set_style_bg_color(cal_button, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(cal_button, 0, 0);
-    lv_obj_set_style_radius(cal_button, THEME_CORNER_RADIUS_PX, 0);
-    
-    lv_obj_t* cal_label = lv_label_create(cal_button);
-    lv_label_set_text(cal_label, "CALIBRATE");
-    lv_obj_set_style_text_font(cal_label, &lv_font_montserrat_24, 0);
-    lv_obj_center(cal_label);
-
-    // Motor test button
-    motor_test_button = lv_btn_create(parent);
-    lv_obj_set_size(motor_test_button, 240, 80);
-    lv_obj_set_style_bg_color(motor_test_button, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(motor_test_button, 0, 0);
-    lv_obj_set_style_radius(motor_test_button, THEME_CORNER_RADIUS_PX, 0);
-    
-    lv_obj_t* motor_test_label = lv_label_create(motor_test_button);
-    lv_label_set_text(motor_test_label, "MOTOR TEST");
-    lv_obj_set_style_text_font(motor_test_label, &lv_font_montserrat_24, 0);
-    lv_obj_center(motor_test_label);
+    tare_button = create_button(parent, "Tare Scale");
+    cal_button = create_button(parent, "Calibrate");
+    motor_test_button = create_button(parent, "Motor Test");
 }
 
-void SettingsScreen::create_reset_page(lv_obj_t* parent) {
+void SettingsScreen::create_data_page(lv_obj_t* parent) {
     lv_obj_set_layout(parent, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(parent, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(parent, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_gap(parent, 20, 0);
-    lv_obj_set_style_pad_top(parent, 20, 0);
     
     // Enable vertical scrolling on the reset page
     lv_obj_set_scroll_dir(parent, LV_DIR_VER);
     lv_obj_set_scrollbar_mode(parent, LV_SCROLLBAR_MODE_AUTO);
 
-    // // Title
-    // lv_obj_t* title = lv_label_create(parent);
-    // lv_label_set_text(title, "Data");
-    // lv_obj_set_style_text_font(title, &lv_font_montserrat_32, 0);
-    // lv_obj_set_style_text_color(title, lv_color_hex(THEME_COLOR_SECONDARY), 0);
 
-    // // Grind Logging separator
-    // create_separator(parent, "Grind Logging");
-
-    // Logging Toggle
-    lv_obj_t* logging_container = lv_obj_create(parent);
-    lv_obj_set_size(logging_container, 260, 80);
-    lv_obj_set_layout(logging_container, LV_LAYOUT_FLEX);
-    lv_obj_set_flex_flow(logging_container, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(logging_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_bg_color(logging_container, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(logging_container, 0, 0);
-    lv_obj_set_style_radius(logging_container, 8, 0);
-    lv_obj_clear_flag(logging_container, LV_OBJ_FLAG_SCROLLABLE);
-
-    lv_obj_t* logging_label = lv_label_create(logging_container);
-    lv_label_set_text(logging_label, "Logging");
-    lv_obj_set_style_text_font(logging_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(logging_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-
-    logging_toggle = lv_switch_create(logging_container);
-    lv_obj_set_size(logging_toggle, 100, 60);
+    create_toggle_row(parent, "Logging", &logging_toggle);
 
     // Sessions info (number of recorded grind sessions)
     sessions_label = lv_label_create(parent);
@@ -455,47 +302,13 @@ void SettingsScreen::create_reset_page(lv_obj_t* parent) {
     lv_label_set_long_mode(measurements_label, LV_LABEL_LONG_WRAP);
     lv_obj_set_style_text_align(measurements_label, LV_TEXT_ALIGN_LEFT, 0);
 
-    // Refresh statistics button (gray color)
-    refresh_stats_button = lv_btn_create(parent);
-    lv_obj_set_size(refresh_stats_button, 200, 60);
-    lv_obj_set_style_bg_color(refresh_stats_button, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(refresh_stats_button, 0, 0);
-    lv_obj_set_style_radius(refresh_stats_button, THEME_CORNER_RADIUS_PX, 0);
-    
-    lv_obj_t* refresh_label = lv_label_create(refresh_stats_button);
-    lv_label_set_text(refresh_label, "REFRESH STATS");
-    lv_obj_set_style_text_font(refresh_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(refresh_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_center(refresh_label);
-
+    refresh_stats_button = create_button(parent, "Refresh Stats");
     // Reset separator
     create_separator(parent, "Reset");
 
-    // Purge Grind History button
-    purge_button = lv_btn_create(parent);
-    lv_obj_set_size(purge_button, 260, 80);
-    lv_obj_set_style_bg_color(purge_button, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(purge_button, 0, 0);
-    lv_obj_set_style_radius(purge_button, THEME_CORNER_RADIUS_PX, 0);
-    
-    lv_obj_t* purge_label = lv_label_create(purge_button);
-    lv_label_set_text(purge_label, "PURGE HISTORY");
-    lv_obj_set_style_text_font(purge_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(purge_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_center(purge_label);
-
-    // Factory Reset button
-    reset_button = lv_btn_create(parent);
-    lv_obj_set_size(reset_button, 260, 80);
-    lv_obj_set_style_bg_color(reset_button, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_border_width(reset_button, 0, 0);
-    lv_obj_set_style_radius(reset_button, THEME_CORNER_RADIUS_PX, 0);
-    
-    lv_obj_t* reset_label = lv_label_create(reset_button);
-    lv_label_set_text(reset_label, "FACTORY RESET");
-    lv_obj_set_style_text_font(reset_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(reset_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_center(reset_label);
+    purge_button = create_button(parent, "Purge History", lv_color_hex(THEME_COLOR_WARNING));
+    lv_obj_set_style_margin_bottom(purge_button, 20, 0); 
+    reset_button = create_button(parent, "Factory Reset", lv_color_hex(THEME_COLOR_ERROR));
 }
 
 void SettingsScreen::show() {
@@ -505,6 +318,7 @@ void SettingsScreen::show() {
     update_brightness_sliders();
     update_bluetooth_startup_toggle();
     update_logging_toggle();
+    refresh_statistics();
 }
 
 void SettingsScreen::hide() {
@@ -649,10 +463,18 @@ void SettingsScreen::update_brightness_sliders() {
 
 void SettingsScreen::update_brightness_labels() {
     if (!brightness_normal_label || !brightness_screensaver_label) return;
-    
+
     int normal_percent = lv_slider_get_value(brightness_normal_slider);
+    if (normal_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT) {
+        normal_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
+        lv_slider_set_value(brightness_normal_slider, HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT, LV_ANIM_OFF);
+    } 
+        
     int screensaver_percent = lv_slider_get_value(brightness_screensaver_slider);
-    
+    if (screensaver_percent < HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT){
+        screensaver_percent = HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT;
+        lv_slider_set_value(brightness_screensaver_slider, HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT, LV_ANIM_OFF);
+    } 
     char normal_text[32];
     char screensaver_text[32];
     
@@ -669,7 +491,7 @@ lv_obj_t* SettingsScreen::create_separator(lv_obj_t* parent, const char* text) {
     lv_obj_set_size(separator_container, 280, 40);
     lv_obj_set_style_bg_opa(separator_container, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(separator_container, 0, 0);
-    lv_obj_set_style_pad_all(separator_container, 0, 0);
+    lv_obj_set_style_pad_ver(separator_container, 10, 0);
     lv_obj_set_layout(separator_container, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(separator_container, LV_FLEX_FLOW_ROW);
     lv_obj_set_flex_align(separator_container, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
@@ -741,18 +563,8 @@ void SettingsScreen::update_logging_toggle() {
 
 lv_obj_t* SettingsScreen::create_menu_item(lv_obj_t* parent, const char* text) {
     lv_obj_t* cont = lv_menu_cont_create(parent);
-
-    // Apply styling directly
-    lv_obj_set_style_radius(cont, THEME_CORNER_RADIUS_PX, 0);
-    lv_obj_set_style_bg_opa(cont, LV_OPA_COVER, 0);
-    lv_obj_set_style_bg_color(cont, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_text_color(cont, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_style_text_font(cont, &lv_font_montserrat_28, 0);
-    lv_obj_set_style_pad_hor(cont, 20, 0);
-
+    style_as_button(cont);
     lv_obj_set_style_margin_bottom(cont, 10, 0);
-    lv_obj_set_style_width(cont, 260, 0);
-    lv_obj_set_style_height(cont, 80, 0);
 
     // Set layout
     lv_obj_set_layout(cont, LV_LAYOUT_FLEX);
@@ -768,3 +580,61 @@ lv_obj_t* SettingsScreen::create_menu_item(lv_obj_t* parent, const char* text) {
 
     return cont;
 }
+
+lv_obj_t* SettingsScreen::create_toggle_row(lv_obj_t* parent, const char* text, lv_obj_t** out_toggle) {
+    lv_obj_t* row_container = lv_obj_create(parent);
+    style_as_button(row_container);
+    lv_obj_set_style_margin_bottom(row_container, 10, 0);
+
+    // Set layout
+    lv_obj_set_layout(row_container, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(row_container, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(row_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+    lv_obj_t* label = lv_label_create(row_container);
+    lv_label_set_text(label, text);
+
+    *out_toggle = lv_switch_create(row_container);
+    lv_obj_set_size(*out_toggle, 80, 40);
+    lv_obj_set_ext_click_area(*out_toggle, 20);
+    
+    return row_container;
+}
+
+lv_obj_t* SettingsScreen::create_slider_row(lv_obj_t* parent, const char* text, lv_obj_t** label, lv_obj_t** slider, lv_color_t slider_color, uint32_t min, uint32_t max) {
+    lv_obj_t* row_container = lv_obj_create(parent);
+    style_as_button(row_container, 260, LV_SIZE_CONTENT);
+    lv_obj_set_style_margin_bottom(row_container, 10, 0);
+    // Set layout
+
+    lv_obj_set_layout(row_container, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(row_container, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(row_container, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_gap(row_container, 20, 0);
+    lv_obj_set_style_pad_all(row_container, 20, 0);
+
+    *label = lv_label_create(row_container);
+    lv_label_set_text(*label, text);
+
+    *slider = lv_slider_create(row_container);
+    lv_obj_set_size(*slider, 220, 40);
+    lv_obj_set_ext_click_area(*slider, 20);
+    lv_slider_set_range(*slider, min, max);
+    lv_obj_set_style_bg_color(*slider, lv_color_hex(THEME_COLOR_BACKGROUND), LV_PART_MAIN);
+    lv_obj_set_style_bg_color(*slider, slider_color, LV_PART_INDICATOR);
+    lv_obj_set_style_bg_opa(*slider, LV_OPA_TRANSP, LV_PART_KNOB);
+
+    
+    return row_container;
+}
+
+// lv_obj_t* SettingsScreen::create_data_label(lv_obj_t* parent, const char* text) {
+//     lv_obj_t* label = lv_label_create(parent);
+//     lv_label_set_text(label, text);
+//     lv_obj_set_style_text_font(label, &lv_font_montserrat_24, 0);
+//     lv_obj_set_style_text_color(label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
+//     lv_obj_set_width(label, 280);
+//     lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+//     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
+//     return label;
+// }

--- a/src/ui/screens/settings_screen.cpp
+++ b/src/ui/screens/settings_screen.cpp
@@ -142,70 +142,29 @@ void SettingsScreen::create_info_page(lv_obj_t* parent) {
     lv_obj_set_layout(parent, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(parent, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(parent, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_gap(parent, 15, 0);
-    lv_obj_set_style_pad_top(parent, 20, 0);
+    lv_obj_set_style_pad_all(parent, 0, 0);
     
     // Enable vertical scrolling for the info page content
     lv_obj_set_scroll_dir(parent, LV_DIR_VER);
     lv_obj_set_scrollbar_mode(parent, LV_SCROLLBAR_MODE_AUTO);
 
-    // // Title
-    // lv_obj_t* title = lv_label_create(parent);
-    // lv_label_set_text(title, "System Info");
-    // lv_obj_set_style_text_font(title, &lv_font_montserrat_32, 0);
-    // lv_obj_set_style_text_color(title, lv_color_hex(THEME_COLOR_SECONDARY), 0);
-
-    // Load cell info
-    info_label = lv_label_create(parent);
-    char initial_loadcell_text[32];
-    snprintf(initial_loadcell_text, sizeof(initial_loadcell_text), "Load Cell: " SYS_WEIGHT_DISPLAY_FORMAT, 0.0f);
-    lv_label_set_text(info_label, initial_loadcell_text);
-    lv_obj_set_style_text_font(info_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(info_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_width(info_label, 280);
-    lv_label_set_long_mode(info_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(info_label, LV_TEXT_ALIGN_LEFT, 0);
-
-    // Uptime
-    uptime_label = lv_label_create(parent);
-    lv_label_set_text(uptime_label, "Uptime: 00:00:00");
-    lv_obj_set_style_text_font(uptime_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(uptime_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_width(uptime_label, 280);
-    lv_label_set_long_mode(uptime_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(uptime_label, LV_TEXT_ALIGN_LEFT, 0);
-
-    // Memory info
-    memory_label = lv_label_create(parent);
-    lv_label_set_text(memory_label, "Free Heap: 0 KB");
-    lv_obj_set_style_text_font(memory_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(memory_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_width(memory_label, 280);
-    lv_label_set_long_mode(memory_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(memory_label, LV_TEXT_ALIGN_LEFT, 0);
-
-    // Version info
-    version_label = lv_label_create(parent);
-    lv_label_set_text(version_label, "Firmware: v" INTERNAL_FIRMWARE_VERSION);
-    lv_obj_set_style_text_font(version_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(version_label, lv_color_hex(THEME_COLOR_TEXT_SECONDARY), 0);
-    lv_obj_set_width(version_label, 280);
-    lv_label_set_long_mode(version_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(version_label, LV_TEXT_ALIGN_LEFT, 0);
-    
-    // Build info
-    build_label = lv_label_create(parent);
     char build_info[64];
-    // Show build number prominently for BLE OTA testing
-    snprintf(build_info, sizeof(build_info), "Build: #%d", BUILD_NUMBER);
-    lv_label_set_text(build_label, build_info);
-    lv_obj_set_style_text_font(build_label, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(build_label, lv_color_hex(THEME_COLOR_TEXT_SECONDARY), 0);
-    lv_obj_set_width(build_label, 280);
-    lv_label_set_long_mode(build_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(build_label, LV_TEXT_ALIGN_LEFT, 0);
-
-    // Stats and refresh button moved to Data tab - Grind Logging section
+    snprintf(build_info, sizeof(build_info), "#%d", BUILD_NUMBER);
+    
+    create_static_data_label(parent, "Firmware:", "v" INTERNAL_FIRMWARE_VERSION);
+    create_static_data_label(parent, "Build:", build_info);    
+    
+    create_separator(parent);
+   
+    create_data_label(parent, "Uptime:", &uptime_label);
+    create_data_label(parent, "RAM:", &memory_label);
+    
+    create_separator(parent);
+    
+    create_data_label(parent, "Instant:", &instant_label);
+    create_data_label(parent, "Smooth:", &smooth_label);
+    create_data_label(parent, "Samples:", &samples_label);
+    create_data_label(parent, "Raw:", &raw_label);
 }
 
 
@@ -277,7 +236,7 @@ void SettingsScreen::create_data_page(lv_obj_t* parent) {
 
     create_data_label(parent, "Sessions:", &sessions_label);
     create_data_label(parent, "Events:", &events_label);
-    create_data_label(parent, "Measurements:", &measurements_label);
+    create_data_label(parent, "Metrics:", &measurements_label);
 
     refresh_stats_button = create_button(parent, "Refresh Stats");
     lv_obj_add_flag(refresh_stats_button, LV_OBJ_FLAG_HIDDEN); // Refresh button is not used anymore
@@ -304,26 +263,26 @@ void SettingsScreen::hide() {
     visible = false;
 }
 
-void SettingsScreen::update_info(const char* load_cell_info, unsigned long uptime_ms, size_t free_heap) {
+void SettingsScreen::update_info(const WeightSensor* weight_sensor, unsigned long uptime_ms, size_t free_heap) {
     if (!visible) return;
-    
-    // Update load cell reading
-    lv_label_set_text(info_label, load_cell_info);
+
+    set_label_text_float(instant_label, weight_sensor->get_instant_weight(), "g");
+    set_label_text_float(smooth_label, weight_sensor->get_weight_high_latency(), "g");
+    set_label_text_int(samples_label, weight_sensor->get_sample_count());
+    set_label_text_int(raw_label, weight_sensor->get_raw_adc_instant());
+
     
     // Update uptime - use compact format to avoid horizontal scrolling
     unsigned long seconds = uptime_ms / 1000;
     unsigned long hours = seconds / 3600;
     unsigned long minutes = (seconds % 3600) / 60;
     seconds = seconds % 60;
-    
+
     char uptime_text[48];
-    snprintf(uptime_text, sizeof(uptime_text), "Up: %02lu:%02lu:%02lu", hours, minutes, seconds);
+    snprintf(uptime_text, sizeof(uptime_text), "%02lu:%02lu:%02lu", hours, minutes, seconds);
     lv_label_set_text(uptime_label, uptime_text);
-    
-    // Update memory info - use compact format
-    char memory_text[48];
-    snprintf(memory_text, sizeof(memory_text), "RAM: %zu KB", free_heap / 1024);
-    lv_label_set_text(memory_label, memory_text);
+
+    set_label_text_int(memory_label, free_heap / 1024, "kB");
 }
 
 void SettingsScreen::update_ble_status() {
@@ -367,40 +326,12 @@ void SettingsScreen::hide_taring_overlay() {
     lv_obj_add_flag(taring_overlay, LV_OBJ_FLAG_HIDDEN);
 }
 
-
-void SettingsScreen::set_session_count(uint32_t count) {
-    if (!sessions_label) return;
-    char buf[48];
-    snprintf(buf, sizeof(buf), "%lu", (unsigned long)count);
-    lv_label_set_text(sessions_label, buf);
-}
-
-void SettingsScreen::set_event_count(uint32_t count) {
-    if (!events_label) return;
-    char buf[48];
-    snprintf(buf, sizeof(buf), "%lu", (unsigned long)count);
-    lv_label_set_text(events_label, buf);
-}
-
-void SettingsScreen::set_measurement_count(uint32_t count) {
-    if (!measurements_label) return;
-    char buf[48];
-    snprintf(buf, sizeof(buf), "%lu", (unsigned long)count);
-    lv_label_set_text(measurements_label, buf);
-}
-
 void SettingsScreen::refresh_statistics() {
     if (!visible) return;
 
-    // Perform the expensive IO operations
-    uint32_t session_count = grind_logger.get_total_flash_sessions();
-    uint32_t event_count = grind_logger.count_total_events_in_flash();
-    uint32_t measurement_count = grind_logger.count_total_measurements_in_flash();
-    
-    // Update with actual values
-    set_session_count(session_count);
-    set_event_count(event_count);
-    set_measurement_count(measurement_count);
+    set_label_text_int(sessions_label, grind_logger.get_total_flash_sessions());
+    set_label_text_int(events_label, grind_logger.count_total_events_in_flash());
+    set_label_text_int(measurements_label, grind_logger.count_total_measurements_in_flash());
 }
 
 void SettingsScreen::update_brightness_sliders() {
@@ -448,10 +379,9 @@ void SettingsScreen::update_brightness_labels(int normal_percent, int screensave
 lv_obj_t* SettingsScreen::create_separator(lv_obj_t* parent, const char* text) {
     // Create separator container
     lv_obj_t* separator_container = lv_obj_create(parent);
-    lv_obj_set_size(separator_container, 280, 40);
+    lv_obj_set_size(separator_container, LV_PCT(100), LV_SIZE_CONTENT);
     lv_obj_set_style_bg_opa(separator_container, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(separator_container, 0, 0);
-    lv_obj_set_style_pad_ver(separator_container, 10, 0);
     lv_obj_set_layout(separator_container, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(separator_container, LV_FLEX_FLOW_ROW);
     lv_obj_set_flex_align(separator_container, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
@@ -463,7 +393,11 @@ lv_obj_t* SettingsScreen::create_separator(lv_obj_t* parent, const char* text) {
     lv_obj_set_flex_grow(left_line, 1);
     lv_obj_set_style_bg_color(left_line, lv_color_hex(THEME_COLOR_TEXT_SECONDARY), 0);
     lv_obj_set_style_border_width(left_line, 0, 0);
-    lv_obj_set_style_radius(left_line, 1, 0);
+
+    if (!text) {
+        // If no text, make the line take full width
+        return separator_container;
+    }
 
     // Create text label
     lv_obj_t* separator_label = lv_label_create(separator_container);
@@ -479,7 +413,6 @@ lv_obj_t* SettingsScreen::create_separator(lv_obj_t* parent, const char* text) {
     lv_obj_set_flex_grow(right_line, 1);
     lv_obj_set_style_bg_color(right_line, lv_color_hex(THEME_COLOR_TEXT_SECONDARY), 0);
     lv_obj_set_style_border_width(right_line, 0, 0);
-    lv_obj_set_style_radius(right_line, 1, 0);
 
     return separator_container;
 }
@@ -584,8 +517,14 @@ lv_obj_t* SettingsScreen::create_slider_row(lv_obj_t* parent, const char* text, 
     lv_obj_set_style_bg_color(*slider, lv_color_hex(THEME_COLOR_BACKGROUND), LV_PART_MAIN);
     lv_obj_set_style_bg_color(*slider, slider_color, LV_PART_INDICATOR);
     lv_obj_set_style_bg_opa(*slider, LV_OPA_TRANSP, LV_PART_KNOB);
-    
     return row_container;
+}
+
+lv_obj_t* SettingsScreen::create_static_data_label(lv_obj_t* parent, const char* name, const char* value) {
+    lv_obj_t* label;
+    lv_obj_t* data_label = create_data_label(parent, name, &label);
+    lv_label_set_text(label, value);
+    return data_label;
 }
 
 lv_obj_t* SettingsScreen::create_data_label(lv_obj_t* parent, const char* name, lv_obj_t** variable) {
@@ -593,8 +532,8 @@ lv_obj_t* SettingsScreen::create_data_label(lv_obj_t* parent, const char* name, 
     lv_obj_set_style_bg_opa(container, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(container, 0, 0);
     lv_obj_set_style_pad_all(container, 2, 0);
-    lv_obj_set_style_pad_left(container, 20, 0);
-    lv_obj_set_style_pad_right(container, 24, 0); // Just a bit away from the scroll bar
+    lv_obj_set_style_pad_left(container, 10, 0);
+    lv_obj_set_style_pad_right(container, 14, 0); // Just a bit away from the scroll bar
     lv_obj_set_style_margin_all(container, 0, 0);
     lv_obj_set_size(container, 280, LV_SIZE_CONTENT);
 
@@ -610,7 +549,6 @@ lv_obj_t* SettingsScreen::create_data_label(lv_obj_t* parent, const char* name, 
     *variable = lv_label_create(container);
     lv_label_set_text(*variable, "");
     lv_obj_set_style_text_font(*variable, &lv_font_montserrat_24, 0);
-    // lv_obj_set_flex_grow(*variable, 1);
     lv_obj_set_style_text_color(*variable, lv_color_hex(THEME_COLOR_TEXT_SECONDARY), 0);
     lv_obj_set_style_text_align(*variable, LV_TEXT_ALIGN_RIGHT, 0);
 

--- a/src/ui/screens/settings_screen.h
+++ b/src/ui/screens/settings_screen.h
@@ -3,6 +3,7 @@
 #include "../../config/ui_theme.h"
 #include "../../bluetooth/manager.h"
 #include "../../controllers/grind_controller.h"
+#include "ui_helpers.h"
 
 class GrindingScreen;  // Forward declaration
 
@@ -92,7 +93,12 @@ private:
     void create_bluetooth_page(lv_obj_t* parent);
     void create_display_page(lv_obj_t* parent);
     void create_tools_page(lv_obj_t* parent);
-    void create_reset_page(lv_obj_t* parent);
+    void create_data_page(lv_obj_t* parent);
     lv_obj_t* create_separator(lv_obj_t* parent, const char* text);
     lv_obj_t* create_menu_item(lv_obj_t* parent, const char* text);
+    lv_obj_t *create_toggle_row(lv_obj_t *parent, const char *text,lv_obj_t **out_toggle);
+    lv_obj_t *create_slider_row(lv_obj_t *parent, const char *text,
+                                lv_obj_t **label, lv_obj_t **slider,
+                                lv_color_t slider_color = lv_color_hex(THEME_COLOR_ACCENT),
+                                uint32_t min = 0, uint32_t max = 100);
 };

--- a/src/ui/screens/settings_screen.h
+++ b/src/ui/screens/settings_screen.h
@@ -101,4 +101,6 @@ private:
                                 lv_obj_t **label, lv_obj_t **slider,
                                 lv_color_t slider_color = lv_color_hex(THEME_COLOR_ACCENT),
                                 uint32_t min = 0, uint32_t max = 100);
+    lv_obj_t *create_data_label(lv_obj_t *parent, const char *name,
+                                lv_obj_t **variable);
 };

--- a/src/ui/screens/settings_screen.h
+++ b/src/ui/screens/settings_screen.h
@@ -21,8 +21,10 @@ private:
     lv_obj_t* info_label;
     lv_obj_t* uptime_label;
     lv_obj_t* memory_label;
-    lv_obj_t* version_label;
-    lv_obj_t* build_label;
+    lv_obj_t* instant_label;
+    lv_obj_t* smooth_label;
+    lv_obj_t* samples_label;
+    lv_obj_t* raw_label;
     lv_obj_t* sessions_label;
     lv_obj_t* events_label;
     lv_obj_t* measurements_label;
@@ -60,11 +62,8 @@ public:
     void create(BluetoothManager* bluetooth, GrindController* grind_ctrl, GrindingScreen* grind_screen, class HardwareManager* hw_mgr);
     void show();
     void hide();
-    void update_info(const char* load_cell_info, unsigned long uptime_ms, size_t free_heap);
+    void update_info(const WeightSensor* weight_sensor, unsigned long uptime_ms, size_t free_heap);
     void update_ble_status();
-    void set_session_count(uint32_t count);
-    void set_event_count(uint32_t count);
-    void set_measurement_count(uint32_t count);
     void refresh_statistics();
     void show_taring_overlay();
     void hide_taring_overlay();
@@ -94,13 +93,15 @@ private:
     void create_display_page(lv_obj_t* parent);
     void create_tools_page(lv_obj_t* parent);
     void create_data_page(lv_obj_t* parent);
-    lv_obj_t* create_separator(lv_obj_t* parent, const char* text);
+    lv_obj_t* create_separator(lv_obj_t* parent, const char* text = nullptr);
     lv_obj_t* create_menu_item(lv_obj_t* parent, const char* text);
     lv_obj_t *create_toggle_row(lv_obj_t *parent, const char *text,lv_obj_t **out_toggle);
     lv_obj_t *create_slider_row(lv_obj_t *parent, const char *text,
                                 lv_obj_t **label, lv_obj_t **slider,
                                 lv_color_t slider_color = lv_color_hex(THEME_COLOR_ACCENT),
                                 uint32_t min = 0, uint32_t max = 100);
+    lv_obj_t *create_static_data_label(lv_obj_t *parent, const char *name,
+                                       const char *value);
     lv_obj_t *create_data_label(lv_obj_t *parent, const char *name,
                                 lv_obj_t **variable);
 };

--- a/src/ui/screens/settings_screen.h
+++ b/src/ui/screens/settings_screen.h
@@ -68,8 +68,8 @@ public:
     void refresh_statistics();
     void show_taring_overlay();
     void hide_taring_overlay();
+    void update_brightness_labels(int normal_percent = -1, int screensaver_percent = -1); // Use negative value to leave unchanged
     void update_brightness_sliders();
-    void update_brightness_labels();
     void update_bluetooth_startup_toggle();
     void update_logging_toggle();
     

--- a/src/ui/screens/settings_screen.h
+++ b/src/ui/screens/settings_screen.h
@@ -9,9 +9,10 @@ class GrindingScreen;  // Forward declaration
 class SettingsScreen {
 private:
     lv_obj_t* screen;
-    lv_obj_t* tabview;
+    lv_obj_t* menu;
     lv_obj_t* info_tab;
-    lv_obj_t* settings_tab;
+    lv_obj_t* bluetooth_tab;
+    lv_obj_t* display_tab;
     lv_obj_t* tools_tab;
     lv_obj_t* reset_tab;
     
@@ -47,7 +48,6 @@ private:
     lv_obj_t* taring_label;
     
     // Common elements
-    lv_obj_t* back_button;
     bool visible;
     
     BluetoothManager* bluetooth_manager;
@@ -74,13 +74,12 @@ public:
     
     bool is_visible() const { return visible; }
     lv_obj_t* get_screen() const { return screen; }
-    lv_obj_t* get_tabview() const { return tabview; }
+    lv_obj_t* get_tabview() const { return menu; }
     lv_obj_t* get_cal_button() const { return cal_button; }
     lv_obj_t* get_purge_button() const { return purge_button; }
     lv_obj_t* get_reset_button() const { return reset_button; }
     lv_obj_t* get_motor_test_button() const { return motor_test_button; }
     lv_obj_t* get_tare_button() const { return tare_button; }
-    lv_obj_t* get_back_button() const { return back_button; }
     lv_obj_t* get_ble_toggle() const { return ble_toggle; }
     lv_obj_t* get_ble_startup_toggle() const { return ble_startup_toggle; }
     lv_obj_t* get_logging_toggle() const { return logging_toggle; }
@@ -90,9 +89,10 @@ public:
     
 private:
     void create_info_page(lv_obj_t* parent);
-    void create_settings_page(lv_obj_t* parent);
+    void create_bluetooth_page(lv_obj_t* parent);
+    void create_display_page(lv_obj_t* parent);
     void create_tools_page(lv_obj_t* parent);
     void create_reset_page(lv_obj_t* parent);
-    void create_back_button();
     lv_obj_t* create_separator(lv_obj_t* parent, const char* text);
+    lv_obj_t* create_menu_item(lv_obj_t* parent, const char* text);
 };

--- a/src/ui/screens/settings_screen.h
+++ b/src/ui/screens/settings_screen.h
@@ -47,8 +47,6 @@ private:
     lv_obj_t* cal_button;
     lv_obj_t* motor_test_button;
     lv_obj_t* tare_button;
-    lv_obj_t* taring_overlay;
-    lv_obj_t* taring_label;
     
     // Common elements
     bool visible;
@@ -65,8 +63,6 @@ public:
     void update_info(const WeightSensor* weight_sensor, unsigned long uptime_ms, size_t free_heap);
     void update_ble_status();
     void refresh_statistics();
-    void show_taring_overlay();
-    void hide_taring_overlay();
     void update_brightness_labels(int normal_percent = -1, int screensaver_percent = -1); // Use negative value to leave unchanged
     void update_brightness_sliders();
     void update_bluetooth_startup_toggle();

--- a/src/ui/screens/ui_helpers.cpp
+++ b/src/ui/screens/ui_helpers.cpp
@@ -103,4 +103,3 @@ lv_obj_t* create_dual_button_row(lv_obj_t* parent, lv_obj_t** left_button, lv_ob
 
     return row_container;
 }
-

--- a/src/ui/screens/ui_helpers.cpp
+++ b/src/ui/screens/ui_helpers.cpp
@@ -1,0 +1,106 @@
+#include "ui_helpers.h"
+#include <cstdio>
+
+void style_as_button(lv_obj_t* object, int32_t width, int32_t height, const lv_font_t* font) {
+    lv_obj_set_style_radius(object, THEME_CORNER_RADIUS_PX, 0);
+    lv_obj_set_style_bg_opa(object, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(object, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
+    lv_obj_set_style_text_color(object, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
+    lv_obj_set_style_text_font(object, font, 0);
+    lv_obj_set_style_border_width(object, 0, 0);
+    lv_obj_set_style_pad_hor(object, 20, 0);
+    if (width >= 0){
+        lv_obj_set_style_width(object, width, 0);
+    }
+    if (height >= 0){
+        lv_obj_set_style_height(object, height, 0);
+    }
+    
+    lv_obj_clear_flag(object, LV_OBJ_FLAG_SCROLLABLE);
+}
+
+lv_obj_t* create_button(lv_obj_t* parent, const char* text, lv_color_t bg_color, int32_t width, int32_t height, const lv_font_t* font){ 
+    lv_obj_t* button = lv_btn_create(parent);
+    style_as_button(button, width, height, font);
+    lv_obj_set_style_bg_color(button, bg_color, 0);
+    
+    lv_obj_t* label = lv_label_create(button);
+    lv_label_set_text(label, text);
+    lv_obj_center(label);
+    
+    return button;  
+}
+
+void set_label_text_int(lv_obj_t* label, int32_t value, const char* unit) {
+    if (!label) return;
+    char buf[24];
+
+    if (unit) {
+        snprintf(buf, sizeof(buf), "%ld %s", value, unit);
+    } else {
+        snprintf(buf, sizeof(buf), "%ld", value);
+    }
+
+    lv_label_set_text(label, buf);
+}
+
+void set_label_text_float(lv_obj_t* label, float value, const char* unit) {
+    if (!label) return;
+    char buf[24];
+    
+    if (unit) {
+        snprintf(buf, sizeof(buf), "%.2fg %s", value, unit);
+    } else {
+        snprintf(buf, sizeof(buf), "%.2f", value);
+    }
+
+    lv_label_set_text(label, buf);
+}
+
+lv_obj_t* create_profile_label(lv_obj_t* parent, lv_obj_t** profile_label, lv_obj_t** weight_label){
+    lv_obj_t* label_container = lv_obj_create(parent);
+    lv_obj_set_size(label_container, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(label_container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(label_container, 0, 0);
+    lv_obj_set_style_pad_all(label_container, 0, 0);
+    
+    // Set up button container as horizontal flex
+    lv_obj_set_layout(label_container, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(label_container, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(label_container, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_gap(label_container, 0, 0);
+
+    *profile_label = lv_label_create(label_container);
+    lv_label_set_text(*profile_label, "DOUBLE");
+    lv_obj_set_style_text_font(*profile_label, &lv_font_montserrat_32, 0);
+    lv_obj_set_style_text_color(*profile_label, lv_color_hex(THEME_COLOR_SECONDARY), 0);
+    
+    *weight_label = lv_label_create(label_container);
+    lv_label_set_text(*weight_label, "18.0g");
+    lv_obj_set_style_text_font(*weight_label, &lv_font_montserrat_60, 0);
+    lv_obj_set_style_text_color(*weight_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
+
+    return label_container;
+}
+
+lv_obj_t* create_dual_button_row(lv_obj_t* parent, lv_obj_t** left_button, lv_obj_t** right_button, const char* left_name, const char* right_name, lv_color_t left_color, lv_color_t right_color, int height, const lv_font_t* font){
+    lv_obj_t *row_container = lv_obj_create(parent);
+    lv_obj_set_size(row_container, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(row_container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(row_container, 0, 0);
+    lv_obj_set_style_pad_all(row_container, 0, 0);
+    
+    lv_obj_set_layout(row_container, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(row_container, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(row_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_gap(row_container, 10, 0);
+
+    *left_button = create_button(row_container, left_name, left_color, -1, height, font);
+    lv_obj_set_flex_grow(*left_button, 1);
+
+    *right_button = create_button(row_container, right_name, right_color, -1, height, font);
+    lv_obj_set_flex_grow(*right_button, 1);
+
+    return row_container;
+}
+

--- a/src/ui/screens/ui_helpers.h
+++ b/src/ui/screens/ui_helpers.h
@@ -2,108 +2,22 @@
 #include <lvgl.h>
 #include "../../config/ui_theme.h"
 
-inline void style_as_button(lv_obj_t* object, int32_t width = 260, int32_t height = 80, const lv_font_t* font = &lv_font_montserrat_28) {
-    lv_obj_set_style_radius(object, THEME_CORNER_RADIUS_PX, 0);
-    lv_obj_set_style_bg_opa(object, LV_OPA_COVER, 0);
-    lv_obj_set_style_bg_color(object, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
-    lv_obj_set_style_text_color(object, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_style_text_font(object, font, 0);
-    lv_obj_set_style_border_width(object, 0, 0);
-    lv_obj_set_style_pad_hor(object, 20, 0);
-    if (width >= 0){
-        lv_obj_set_style_width(object, width, 0);
-    }
-    if (height >= 0){
-        lv_obj_set_style_height(object, height, 0);
-    }
-    
-    lv_obj_clear_flag(object, LV_OBJ_FLAG_SCROLLABLE);   
-}
+// Function declarations
+void style_as_button(lv_obj_t* object, int32_t width = 260, int32_t height = 80, const lv_font_t* font = &lv_font_montserrat_28);
 
-inline lv_obj_t* create_button(lv_obj_t* parent, const char* text,
-                                lv_color_t bg_color = lv_color_hex(THEME_COLOR_NEUTRAL),
-                                int32_t width = 260, int32_t height = 80, const lv_font_t* font = &lv_font_montserrat_28){ 
-    lv_obj_t* button = lv_btn_create(parent);
-    style_as_button(button, width, height, font);
-    lv_obj_set_style_bg_color(button, bg_color, 0);
-    
-    lv_obj_t* label = lv_label_create(button);
-    lv_label_set_text(label, text);
-    lv_obj_center(label);
-    
-    return button;  
-}
+lv_obj_t* create_button(lv_obj_t* parent, const char* text,
+                       lv_color_t bg_color = lv_color_hex(THEME_COLOR_NEUTRAL),
+                       int32_t width = 260, int32_t height = 80, 
+                       const lv_font_t* font = &lv_font_montserrat_28);
 
-inline void set_label_text_int(lv_obj_t* label, int32_t value, const char* unit = nullptr) {
-    if (!label) return;
-    char buf[24];
+void set_label_text_int(lv_obj_t* label, int32_t value, const char* unit = nullptr);
 
-    if (unit) {
-        snprintf(buf, sizeof(buf), "%ld %s", value, unit);
-    } else {
-        snprintf(buf, sizeof(buf), "%ld", value);
-    }
+void set_label_text_float(lv_obj_t* label, float value, const char* unit = nullptr);
 
-    lv_label_set_text(label, buf);
-}
+lv_obj_t* create_profile_label(lv_obj_t* parent, lv_obj_t** profile_label, lv_obj_t** weight_label);
 
-inline void set_label_text_float(lv_obj_t* label, float value, const char* unit = nullptr) {
-    if (!label) return;
-    char buf[24];
-    
-    if (unit) {
-        snprintf(buf, sizeof(buf), "%.2fg %s", value, unit);
-    } else {
-        snprintf(buf, sizeof(buf), "%.2f", value);
-    }
-
-    lv_label_set_text(label, buf);
-}
-
-inline lv_obj_t* create_profile_label(lv_obj_t* parent, lv_obj_t** profile_label, lv_obj_t** weight_label){
-    lv_obj_t* label_container = lv_obj_create(parent);
-    lv_obj_set_size(label_container, LV_PCT(100), LV_SIZE_CONTENT);
-    lv_obj_set_style_bg_opa(label_container, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_width(label_container, 0, 0);
-    lv_obj_set_style_pad_all(label_container, 0, 0);
-    
-    // Set up button container as horizontal flex
-    lv_obj_set_layout(label_container, LV_LAYOUT_FLEX);
-    lv_obj_set_flex_flow(label_container, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_flex_align(label_container, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_gap(label_container, 0, 0);
-
-    *profile_label = lv_label_create(label_container);
-    lv_label_set_text(*profile_label, "DOUBLE");
-    lv_obj_set_style_text_font(*profile_label, &lv_font_montserrat_32, 0);
-    lv_obj_set_style_text_color(*profile_label, lv_color_hex(THEME_COLOR_SECONDARY), 0);
-    
-    *weight_label = lv_label_create(label_container);
-    lv_label_set_text(*weight_label, "18.0g");
-    lv_obj_set_style_text_font(*weight_label, &lv_font_montserrat_60, 0);
-    lv_obj_set_style_text_color(*weight_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-
-    return label_container;
-}
-
-inline lv_obj_t* create_dual_button_row(lv_obj_t* parent, lv_obj_t** left_button, lv_obj_t** right_button, const char* left_name, const char* right_name, lv_color_t left_color = lv_color_hex(THEME_COLOR_NEUTRAL), lv_color_t right_color = lv_color_hex(THEME_COLOR_NEUTRAL), int height = 80, const lv_font_t* font = &lv_font_montserrat_28){
-    lv_obj_t *row_container = lv_obj_create(parent);
-    lv_obj_set_size(row_container, LV_PCT(100), LV_SIZE_CONTENT);
-    lv_obj_set_style_bg_opa(row_container, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_width(row_container, 0, 0);
-    lv_obj_set_style_pad_all(row_container, 0, 0);
-    
-    lv_obj_set_layout(row_container, LV_LAYOUT_FLEX);
-    lv_obj_set_flex_flow(row_container, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(row_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_gap(row_container, 10, 0);
-
-    *left_button = create_button(row_container, left_name, left_color, -1, height, font);
-    lv_obj_set_flex_grow(*left_button, 1);
-
-    *right_button = create_button(row_container, right_name, right_color, -1, height, font);
-    lv_obj_set_flex_grow(*right_button, 1);
-
-    return row_container;
-}
-
+lv_obj_t* create_dual_button_row(lv_obj_t* parent, lv_obj_t** left_button, lv_obj_t** right_button, 
+                                const char* left_name, const char* right_name, 
+                                lv_color_t left_color = lv_color_hex(THEME_COLOR_NEUTRAL), 
+                                lv_color_t right_color = lv_color_hex(THEME_COLOR_NEUTRAL), 
+                                int height = 80, const lv_font_t* font = &lv_font_montserrat_28);

--- a/src/ui/screens/ui_helpers.h
+++ b/src/ui/screens/ui_helpers.h
@@ -10,7 +10,12 @@ inline void style_as_button(lv_obj_t* object, int32_t width = 260, int32_t heigh
     lv_obj_set_style_text_font(object, &lv_font_montserrat_28, 0);
     lv_obj_set_style_border_width(object, 0, 0);
     lv_obj_set_style_pad_hor(object, 20, 0);
-    lv_obj_set_style_size(object, width, height, 0);
+    if (width >= 0){
+        lv_obj_set_style_width(object, width, 0);
+    }
+    if (height >= 0){
+        lv_obj_set_style_height(object, height, 0);
+    }
     
     lv_obj_clear_flag(object, LV_OBJ_FLAG_SCROLLABLE);   
 }

--- a/src/ui/screens/ui_helpers.h
+++ b/src/ui/screens/ui_helpers.h
@@ -2,12 +2,12 @@
 #include <lvgl.h>
 #include "../../config/ui_theme.h"
 
-inline void style_as_button(lv_obj_t* object, int32_t width = 260, int32_t height = 80) {
+inline void style_as_button(lv_obj_t* object, int32_t width = 260, int32_t height = 80, const lv_font_t* font = &lv_font_montserrat_28) {
     lv_obj_set_style_radius(object, THEME_CORNER_RADIUS_PX, 0);
     lv_obj_set_style_bg_opa(object, LV_OPA_COVER, 0);
     lv_obj_set_style_bg_color(object, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
     lv_obj_set_style_text_color(object, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
-    lv_obj_set_style_text_font(object, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_font(object, font, 0);
     lv_obj_set_style_border_width(object, 0, 0);
     lv_obj_set_style_pad_hor(object, 20, 0);
     if (width >= 0){
@@ -22,9 +22,9 @@ inline void style_as_button(lv_obj_t* object, int32_t width = 260, int32_t heigh
 
 inline lv_obj_t* create_button(lv_obj_t* parent, const char* text,
                                 lv_color_t bg_color = lv_color_hex(THEME_COLOR_NEUTRAL),
-                                int32_t width = 260, int32_t height = 80){ 
+                                int32_t width = 260, int32_t height = 80, const lv_font_t* font = &lv_font_montserrat_28){ 
     lv_obj_t* button = lv_btn_create(parent);
-    style_as_button(button, width, height);
+    style_as_button(button, width, height, font);
     lv_obj_set_style_bg_color(button, bg_color, 0);
     
     lv_obj_t* label = lv_label_create(button);
@@ -86,4 +86,24 @@ inline lv_obj_t* create_profile_label(lv_obj_t* parent, lv_obj_t** profile_label
     return label_container;
 }
 
-inline
+inline lv_obj_t* create_dual_button_row(lv_obj_t* parent, lv_obj_t** left_button, lv_obj_t** right_button, const char* left_name, const char* right_name, lv_color_t left_color = lv_color_hex(THEME_COLOR_NEUTRAL), lv_color_t right_color = lv_color_hex(THEME_COLOR_NEUTRAL), int height = 80, const lv_font_t* font = &lv_font_montserrat_28){
+    lv_obj_t *row_container = lv_obj_create(parent);
+    lv_obj_set_size(row_container, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(row_container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(row_container, 0, 0);
+    lv_obj_set_style_pad_all(row_container, 0, 0);
+    
+    lv_obj_set_layout(row_container, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(row_container, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(row_container, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_gap(row_container, 10, 0);
+
+    *left_button = create_button(row_container, left_name, left_color, -1, height, font);
+    lv_obj_set_flex_grow(*left_button, 1);
+
+    *right_button = create_button(row_container, right_name, right_color, -1, height, font);
+    lv_obj_set_flex_grow(*right_button, 1);
+
+    return row_container;
+}
+

--- a/src/ui/screens/ui_helpers.h
+++ b/src/ui/screens/ui_helpers.h
@@ -59,3 +59,31 @@ inline void set_label_text_float(lv_obj_t* label, float value, const char* unit 
 
     lv_label_set_text(label, buf);
 }
+
+inline lv_obj_t* create_profile_label(lv_obj_t* parent, lv_obj_t** profile_label, lv_obj_t** weight_label){
+    lv_obj_t* label_container = lv_obj_create(parent);
+    lv_obj_set_size(label_container, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(label_container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(label_container, 0, 0);
+    lv_obj_set_style_pad_all(label_container, 0, 0);
+    
+    // Set up button container as horizontal flex
+    lv_obj_set_layout(label_container, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(label_container, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(label_container, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_gap(label_container, 0, 0);
+
+    *profile_label = lv_label_create(label_container);
+    lv_label_set_text(*profile_label, "DOUBLE");
+    lv_obj_set_style_text_font(*profile_label, &lv_font_montserrat_32, 0);
+    lv_obj_set_style_text_color(*profile_label, lv_color_hex(THEME_COLOR_SECONDARY), 0);
+    
+    *weight_label = lv_label_create(label_container);
+    lv_label_set_text(*weight_label, "18.0g");
+    lv_obj_set_style_text_font(*weight_label, &lv_font_montserrat_60, 0);
+    lv_obj_set_style_text_color(*weight_label, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
+
+    return label_container;
+}
+
+inline

--- a/src/ui/screens/ui_helpers.h
+++ b/src/ui/screens/ui_helpers.h
@@ -28,3 +28,29 @@ inline lv_obj_t* create_button(lv_obj_t* parent, const char* text,
     
     return button;  
 }
+
+inline void set_label_text_int(lv_obj_t* label, int32_t value, const char* unit = nullptr) {
+    if (!label) return;
+    char buf[24];
+
+    if (unit) {
+        snprintf(buf, sizeof(buf), "%ld %s", value, unit);
+    } else {
+        snprintf(buf, sizeof(buf), "%ld", value);
+    }
+
+    lv_label_set_text(label, buf);
+}
+
+inline void set_label_text_float(lv_obj_t* label, float value, const char* unit = nullptr) {
+    if (!label) return;
+    char buf[24];
+    
+    if (unit) {
+        snprintf(buf, sizeof(buf), "%.2fg %s", value, unit);
+    } else {
+        snprintf(buf, sizeof(buf), "%.2f", value);
+    }
+
+    lv_label_set_text(label, buf);
+}

--- a/src/ui/screens/ui_helpers.h
+++ b/src/ui/screens/ui_helpers.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <lvgl.h>
+#include "../../config/ui_theme.h"
+
+inline void style_as_button(lv_obj_t* object, int32_t width = 260, int32_t height = 80) {
+    lv_obj_set_style_radius(object, THEME_CORNER_RADIUS_PX, 0);
+    lv_obj_set_style_bg_opa(object, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(object, lv_color_hex(THEME_COLOR_NEUTRAL), 0);
+    lv_obj_set_style_text_color(object, lv_color_hex(THEME_COLOR_TEXT_PRIMARY), 0);
+    lv_obj_set_style_text_font(object, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_border_width(object, 0, 0);
+    lv_obj_set_style_pad_hor(object, 20, 0);
+    lv_obj_set_style_size(object, width, height, 0);
+    
+    lv_obj_clear_flag(object, LV_OBJ_FLAG_SCROLLABLE);   
+}
+
+inline lv_obj_t* create_button(lv_obj_t* parent, const char* text,
+                                lv_color_t bg_color = lv_color_hex(THEME_COLOR_NEUTRAL),
+                                int32_t width = 260, int32_t height = 80){ 
+    lv_obj_t* button = lv_btn_create(parent);
+    style_as_button(button, width, height);
+    lv_obj_set_style_bg_color(button, bg_color, 0);
+    
+    lv_obj_t* label = lv_label_create(button);
+    lv_label_set_text(label, text);
+    lv_obj_center(label);
+    
+    return button;  
+}

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -250,7 +250,6 @@ void UIManager::setup_event_handlers() {
     lv_obj_add_event_cb(settings_screen.get_reset_button(), EventBridgeLVGL::dispatch_event, LV_EVENT_CLICKED, EVENT_DATA(SETTINGS_RESET));
     lv_obj_add_event_cb(settings_screen.get_motor_test_button(), EventBridgeLVGL::dispatch_event, LV_EVENT_CLICKED, EVENT_DATA(SETTINGS_MOTOR_TEST));
     lv_obj_add_event_cb(settings_screen.get_tare_button(), EventBridgeLVGL::dispatch_event, LV_EVENT_CLICKED, EVENT_DATA(SETTINGS_TARE));
-    lv_obj_add_event_cb(settings_screen.get_back_button(), EventBridgeLVGL::dispatch_event, LV_EVENT_CLICKED, EVENT_DATA(SETTINGS_BACK));
     lv_obj_add_event_cb(settings_screen.get_refresh_stats_button(), EventBridgeLVGL::dispatch_event, LV_EVENT_CLICKED, EVENT_DATA(SETTINGS_REFRESH_STATS));
     lv_obj_add_event_cb(settings_screen.get_ble_toggle(), EventBridgeLVGL::dispatch_event, LV_EVENT_VALUE_CHANGED, EVENT_DATA(BLE_TOGGLE));
     lv_obj_add_event_cb(settings_screen.get_ble_startup_toggle(), EventBridgeLVGL::dispatch_event, LV_EVENT_VALUE_CHANGED, EVENT_DATA(BLE_STARTUP_TOGGLE));

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -935,21 +935,11 @@ void UIManager::stop_data_export_ui() {
 void UIManager::update_settings_state() {
     // Update developer screen with comprehensive system info
     WeightSensor* lc = hardware_manager->get_weight_sensor();
-    // Show both instant and high-latency weight for diagnostic purposes
-    float weight_instant = lc->get_instant_weight();
-    float weight_smoothed = lc->get_weight_high_latency();
-    int32_t raw_reading = lc->get_raw_adc_instant();
-    int sample_count = lc->get_sample_count();
-    
-    char leight_sensor_info[256];
-    snprintf(leight_sensor_info, sizeof(leight_sensor_info), 
-        "Instant: %.2fg\nSmoothed: %.2fg\nSamples: %d\nRaw: %ld", 
-        weight_instant, weight_smoothed, sample_count, (long)raw_reading);
     
     unsigned long uptime_ms = millis();
     size_t free_heap = ESP.getFreeHeap();
     
-    settings_screen.update_info(leight_sensor_info, uptime_ms, free_heap);
+    settings_screen.update_info(lc, uptime_ms, free_heap);
     settings_screen.update_ble_status();
 }
 


### PR DESCRIPTION
This PR refactors the UI layer to eliminate code duplication by creating reusable components. The main focus was consolidating common button patterns and screen elements that were copy-pasted across multiple screens.

Changes Made
  - Created reusable UI helpers - Split ui_helpers into proper source/header files with common button and layout functions
  - Updated screens to use shared components - Refactored calibration, confirm, edit, and info screens to use the new helpers instead of duplicate code
  - Added dual button row helper - New utility for screens that need side-by-side button layouts
  - Improved blocking overlay - Made the "please wait" text a separate label with better styling (smaller, gray text)
  - Removed unused overlay code - Cleaned up old overlay implementations that were replaced by the blocking overlay class
  
Please note that this branch was made on top of the new settings UI. If new settings UI is not wanted, I can refactor this to only have the new shared UI elements