### PR TITLE
Fix BLE crashes: toggle crash, report generation, and mid-report disconnect

### DIFF
--- a/src/bluetooth/manager.cpp
+++ b/src/bluetooth/manager.cpp
@@ -301,15 +301,17 @@ void BluetoothManager::disable() {
         stop_data_export();
     }
     
+    // Set flags before deinit so that callbacks fired during teardown
+    // (e.g. onDisconnect → start_advertising) see BLE as already disabled.
+    ble_enabled = false;
+    device_connected = false;
+
     stop_advertising();
     delay(BLE_SHUTDOWN_ADVERTISING_DELAY_MS);
-    
+
     log("Bluetooth: Deinitializing BLE stack...\n");
     BLEDevice::deinit(false);
     delay(BLE_SHUTDOWN_DEINIT_DELAY_MS);
-    
-    ble_enabled = false;
-    device_connected = false;
     ble_server = nullptr;
     ota_service = nullptr;
     data_service = nullptr;
@@ -850,19 +852,19 @@ void BluetoothManager::onConnect(BLEServer* server) {
 void BluetoothManager::onDisconnect(BLEServer* server) {
     device_connected = false;
     last_disconnect_time = millis(); // Reset timeout countdown from now
-    
+
     log("BLE: Client disconnected - timeout countdown resumed\n");
-    
+
     if (ota_handler.is_ota_active()) {
         ota_handler.abort_ota();
     }
-    
+
     if (data_export_in_progress) {
         stop_data_export();
     }
-    
+
     debug_stream_active = false;
-    
+
     // Restart advertising for next connection
     delay(500);
     start_advertising();
@@ -1070,15 +1072,16 @@ void BluetoothManager::generate_diagnostic_report() {
     char buf[512];
 
     // Helper lambda to send chunk and flush in flow-controlled slices
-    auto send_chunk = [this](const char* chunk) {
-        if (!debug_tx_characteristic || !chunk) return;
+    auto send_chunk = [this](const char* chunk) -> bool {
+        if (!debug_tx_characteristic || !chunk || !device_connected) return false;
         size_t len = strlen(chunk);
-        if (len == 0) return;
+        if (len == 0) return true;
 
         const TickType_t chunk_delay = pdMS_TO_TICKS(BLE_DEBUG_CHUNK_DELAY_MS);
 
         size_t offset = 0;
         while (offset < len) {
+            if (!device_connected) return false;
             size_t part_len = std::min(static_cast<size_t>(BLE_DEBUG_MAX_CHUNK_BYTES), len - offset);
             LOG_BLE("TX: %zu bytes\n", part_len);
             debug_tx_characteristic->setValue(reinterpret_cast<const uint8_t*>(chunk + offset), part_len);
@@ -1086,6 +1089,7 @@ void BluetoothManager::generate_diagnostic_report() {
             vTaskDelay(chunk_delay); // Give BLE stack time to drain queue
             offset += part_len;
         }
+        return true;
     };
 
     // Section 1: Header & Firmware Info
@@ -1625,8 +1629,8 @@ void BluetoothManager::generate_diagnostic_report() {
                                         // Calculate event yield (delta)
                                         float event_yield = event.end_weight - event.start_weight;
 
-                                        // Build base event string
-                                        char base_str[256];
+                                        // Build base event string (static to avoid stack pressure in BLE task)
+                                        static char base_str[256];
                                         if (event.pulse_attempt_number > 0) {
                                             snprintf(base_str, sizeof(base_str),
                                                 "    [%lums] %s (pulse #%u): %.2fg -> %.2fg (%+.2fg) (%.1fms pulse)",
@@ -1650,8 +1654,9 @@ void BluetoothManager::generate_diagnostic_report() {
                                             );
                                         }
 
-                                        // Build phase-specific metrics suffix
-                                        char metrics_str[256] = "";
+                                        // Build phase-specific metrics suffix (static to avoid stack pressure in BLE task)
+                                        static char metrics_str[256];
+                                        metrics_str[0] = '\0';
 
                                         switch (event.phase_id) {
                                             case 5: // PREDICTIVE

--- a/src/config/system.h
+++ b/src/config/system.h
@@ -35,7 +35,7 @@
 #define SYS_TASK_WEIGHT_SAMPLING_STACK_SIZE 4096                               // 4KB stack for weight sampling (was 2KB, increased for BLE_LOG)
 #define SYS_TASK_GRIND_CONTROL_STACK_SIZE 6144                                 // 6KB stack for grind control logic (was 4KB, increased for complex algorithms)
 #define SYS_TASK_UI_STACK_SIZE 8192                                            // 8KB stack for LVGL rendering (unchanged)
-#define SYS_TASK_BLUETOOTH_STACK_SIZE 4096                                     // 4KB stack for BLE operations (unchanged)
+#define SYS_TASK_BLUETOOTH_STACK_SIZE 4096                                     // 4KB stack for BLE operations
 #define SYS_TASK_FILE_IO_STACK_SIZE 6144                                       // 6KB stack for LittleFS operations (was 4KB, increased for file operations)
 
 // Task Priorities (higher number = higher priority)


### PR DESCRIPTION
- Move ble_enabled=false before BLEDevice::deinit() in disable() to prevent onDisconnect callback from calling start_advertising() on a torn-down stack, which caused a crash when toggling Bluetooth off and back on
- Guard send_chunk against notify() calls on disconnected device to prevent crash when client disconnects mid-report
- Make base_str and metrics_str in generate_diagnostic_report() static to reduce BLE task stack depth by 512 bytes, preventing stack overflow during report generation