### PR TITLE
feat: Add custom screensaver image upload and display

### DIFF
--- a/docs/DOC.md
+++ b/docs/DOC.md
@@ -232,6 +232,11 @@ ESP32-S3 GND       →    Pin 4 (Ground)
 - ✅ **Automatic version listing** - all releases available in dropdown
 - ✅ **Wireless updates** - once installed, never need USB again
 
+**Screensaver tools:**
+- Upload a custom 280 × 456 image from the **Screensaver** tab
+- Configure idle timeout (30-3600 seconds) and startup image timeout (1-30 seconds)
+- Screensaver brightness and startup/sleep enable toggles remain on the grinder under **Menu → Display**
+
 *Initial USB flashing powered by [ESP Web Tools](https://esphome.github.io/esp-web-tools/)*
 
 ### Command Line (Fallback)
@@ -345,6 +350,7 @@ Need a simple live readout? Open **Menu → Scale** to jump into a full-screen w
 - **Arc Layout**: Clean, minimal arc-based interface
 - **Nerdy Layout**: Detailed charts showing flow rates and real-time grinding analytics
 - **Switching**: Tap anywhere on grind screen to switch between layouts during grinding
+- **Screensaver**: Custom image can show on startup or when the display dims. During BLE OTA updates and OTA failure warnings, the screensaver is disabled so progress and recovery prompts stay visible.
 
 ---
 
@@ -381,9 +387,10 @@ Main Screen (swipe left/right between tabs, up/down to toggle weight/time mode i
     |   |   |-- Connection status display
     |   |   \-- Auto-disable timer display
     |   |
-    |   +-- Display
-    |   |   |-- Normal brightness slider
-    |   |   \-- Screensaver brightness slider
+	    |   +-- Display
+	    |   |   |-- Normal brightness slider
+	    |   |   |-- Screensaver brightness slider
+	    |   |   \-- Screensaver startup/sleep toggles
     |   |
     |   \-- Grind Settings
     |       |-- Swipe Gestures toggle (enable/disable vertical swipes)

--- a/docs/DOC.md
+++ b/docs/DOC.md
@@ -35,6 +35,7 @@ Complete build instructions, parts list, and usage guide for the Smart Grind-by-
   - [🔍 Diagnostic Report](#-diagnostic-report)
     - [Report Contents](#report-contents)
     - [Access Methods](#access-methods)
+  - [Screensaver](#screensaver)
   - [📊 Analytics \& Data Export](#-analytics--data-export)
     - [Launch Interactive Dashboard](#launch-interactive-dashboard)
     - [Available Tools](#available-tools)
@@ -350,7 +351,7 @@ Need a simple live readout? Open **Menu → Scale** to jump into a full-screen w
 - **Arc Layout**: Clean, minimal arc-based interface
 - **Nerdy Layout**: Detailed charts showing flow rates and real-time grinding analytics
 - **Switching**: Tap anywhere on grind screen to switch between layouts during grinding
-- **Screensaver**: Custom image can show on startup or when the display dims. During BLE OTA updates and OTA failure warnings, the screensaver is disabled so progress and recovery prompts stay visible.
+- **Screensaver**: Custom image can show on startup or when the display dims.
 
 ---
 
@@ -493,6 +494,17 @@ python3 tools/grinder.py diagnostics --save diagnostic-report.txt
 - Checking motor latency settings after auto-tune
 - Confirming firmware version and compile-time parameters
 - General troubleshooting and system health assessment
+
+---
+
+## Screensaver
+
+The screensaver uses a custom 280 × 456 RGB565 image uploaded from the Web Flasher.
+
+- **Timing settings**: Configure idle timeout and startup image timeout in the Web Flasher **Screensaver** tab.
+- **Device settings**: Configure brightness and startup/sleep enable toggles under **Menu → Display**.
+- **Startup behavior**: On normal Ready boots, the image is drawn early while the full UI initializes, then the regular timed screensaver overlay takes over.
+- **OTA behavior**: During BLE OTA updates and OTA failure warnings, the screensaver is disabled so progress and recovery prompts stay visible.
 
 ---
 

--- a/src/bluetooth/image_upload_handler.cpp
+++ b/src/bluetooth/image_upload_handler.cpp
@@ -1,0 +1,192 @@
+#include "image_upload_handler.h"
+#include "ota_handler.h"
+#include "../config/constants.h"
+#include "../config/logging.h"
+
+ImageUploadHandler::ImageUploadHandler()
+    : ota_handler_(nullptr)
+    , expected_size_(0)
+    , received_size_(0)
+    , upload_in_progress_(false)
+    , current_status_(BLE_IMG_STATUS_IDLE) {
+}
+
+void ImageUploadHandler::init(OTAHandler* ota) {
+    ota_handler_ = ota;
+    LOG_BLE("Image Upload: Handler initialized\n");
+}
+
+bool ImageUploadHandler::start_upload(uint32_t file_size) {
+    if (upload_in_progress_) {
+        LOG_BLE("Image Upload: Upload already in progress\n");
+        current_status_ = BLE_IMG_STATUS_ERROR;
+        return false;
+    }
+
+    // Reject if OTA is active
+    if (ota_handler_ && ota_handler_->is_ota_active()) {
+        LOG_BLE("Image Upload: Rejected - OTA update in progress\n");
+        current_status_ = BLE_IMG_STATUS_ERROR;
+        return false;
+    }
+
+    // Validate expected file size
+    if (file_size != BLE_IMAGE_EXPECTED_SIZE) {
+        LOG_BLE("Image Upload: Invalid size %lu (expected %d)\n",
+                (unsigned long)file_size, BLE_IMAGE_EXPECTED_SIZE);
+        current_status_ = BLE_IMG_STATUS_ERROR;
+        return false;
+    }
+
+    // Clean up any leftover temp file
+    cleanup_temp_file();
+
+    // Open temp file for writing
+    temp_file_ = LittleFS.open(BLE_IMAGE_TEMP_FILENAME, "w");
+    if (!temp_file_) {
+        LOG_BLE("Image Upload: Failed to open temp file for writing\n");
+        current_status_ = BLE_IMG_STATUS_ERROR;
+        return false;
+    }
+
+    expected_size_ = file_size;
+    received_size_ = 0;
+    upload_in_progress_ = true;
+    current_status_ = BLE_IMG_STATUS_RECEIVING;
+
+    LOG_BLE("Image Upload: Started (%lu bytes expected)\n", (unsigned long)expected_size_);
+    return true;
+}
+
+bool ImageUploadHandler::process_chunk(const uint8_t* data, size_t size) {
+    if (!upload_in_progress_ || !temp_file_) {
+        return false;
+    }
+
+    // Check for overflow
+    if (received_size_ + size > expected_size_) {
+        LOG_BLE("Image Upload: Data overflow (%lu + %u > %lu)\n",
+                (unsigned long)received_size_, (unsigned)size, (unsigned long)expected_size_);
+        current_status_ = BLE_IMG_STATUS_ERROR;
+        abort_upload();
+        return false;
+    }
+
+    size_t written = temp_file_.write(data, size);
+    if (written != size) {
+        LOG_BLE("Image Upload: Write failed (wrote %u of %u bytes)\n",
+                (unsigned)written, (unsigned)size);
+        current_status_ = BLE_IMG_STATUS_ERROR;
+        abort_upload();
+        return false;
+    }
+
+    received_size_ += size;
+
+    // Progress logging every 32KB
+    if (received_size_ % 32768 == 0 || received_size_ == expected_size_) {
+        LOG_BLE("Image Upload: %lu / %lu bytes (%.0f%%)\n",
+                (unsigned long)received_size_, (unsigned long)expected_size_, get_progress());
+    }
+
+    return true;
+}
+
+bool ImageUploadHandler::complete_upload() {
+    if (!upload_in_progress_) {
+        LOG_BLE("Image Upload: No upload in progress\n");
+        current_status_ = BLE_IMG_STATUS_ERROR;
+        return false;
+    }
+
+    // Close the temp file
+    temp_file_.close();
+
+    // Verify received size
+    if (received_size_ != expected_size_) {
+        LOG_BLE("Image Upload: Size mismatch - expected %lu, got %lu\n",
+                (unsigned long)expected_size_, (unsigned long)received_size_);
+        cleanup_temp_file();
+        upload_in_progress_ = false;
+        current_status_ = BLE_IMG_STATUS_ERROR;
+        return false;
+    }
+
+    // Remove existing image if present
+    if (LittleFS.exists(BLE_IMAGE_FILENAME)) {
+        LittleFS.remove(BLE_IMAGE_FILENAME);
+    }
+
+    // Rename temp file to final filename
+    if (!LittleFS.rename(BLE_IMAGE_TEMP_FILENAME, BLE_IMAGE_FILENAME)) {
+        LOG_BLE("Image Upload: Failed to rename temp file\n");
+        cleanup_temp_file();
+        upload_in_progress_ = false;
+        current_status_ = BLE_IMG_STATUS_ERROR;
+        return false;
+    }
+
+    upload_in_progress_ = false;
+
+    // Verify file exists after rename
+    if (!LittleFS.exists(BLE_IMAGE_FILENAME)) {
+        LOG_BLE("Image Upload: File missing after rename\n");
+        current_status_ = BLE_IMG_STATUS_ERROR;
+        return false;
+    }
+
+    current_status_ = BLE_IMG_STATUS_SUCCESS;
+    LOG_BLE("Image Upload: Complete (%lu bytes)\n", (unsigned long)received_size_);
+    return true;
+}
+
+void ImageUploadHandler::abort_upload() {
+    if (upload_in_progress_) {
+        LOG_BLE("Image Upload: Aborting\n");
+        if (temp_file_) {
+            temp_file_.close();
+        }
+        cleanup_temp_file();
+        upload_in_progress_ = false;
+        received_size_ = 0;
+        expected_size_ = 0;
+        current_status_ = BLE_IMG_STATUS_IDLE;
+    }
+}
+
+bool ImageUploadHandler::delete_image() {
+    if (upload_in_progress_) {
+        abort_upload();
+    }
+
+    if (LittleFS.exists(BLE_IMAGE_FILENAME)) {
+        if (LittleFS.remove(BLE_IMAGE_FILENAME)) {
+            LOG_BLE("Image Upload: Screensaver image deleted\n");
+            current_status_ = BLE_IMG_STATUS_IDLE;
+            return true;
+        } else {
+            LOG_BLE("Image Upload: Failed to delete image\n");
+            current_status_ = BLE_IMG_STATUS_ERROR;
+            return false;
+        }
+    }
+
+    LOG_BLE("Image Upload: No image to delete\n");
+    current_status_ = BLE_IMG_STATUS_IDLE;
+    return true;
+}
+
+bool ImageUploadHandler::has_image() const {
+    return LittleFS.exists(BLE_IMAGE_FILENAME);
+}
+
+float ImageUploadHandler::get_progress() const {
+    if (expected_size_ == 0) return 0.0f;
+    return 100.0f * received_size_ / expected_size_;
+}
+
+void ImageUploadHandler::cleanup_temp_file() {
+    if (LittleFS.exists(BLE_IMAGE_TEMP_FILENAME)) {
+        LittleFS.remove(BLE_IMAGE_TEMP_FILENAME);
+    }
+}

--- a/src/bluetooth/image_upload_handler.h
+++ b/src/bluetooth/image_upload_handler.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <Arduino.h>
+#include <LittleFS.h>
+#include <cstdint>
+
+// Image upload command bytes (sent via data control characteristic)
+// Uses 0x30+ range to avoid conflicts with data export commands (0x11-0x15)
+enum BLEImageCommand {
+    BLE_IMG_CMD_START  = 0x30,  // [0x30][file_size:4 LE] - begin upload
+    BLE_IMG_CMD_DATA   = 0x31,  // Implicit - raw data sent to data transfer char
+    BLE_IMG_CMD_END    = 0x32,  // [0x32] - finalize upload
+    BLE_IMG_CMD_ABORT  = 0x33,  // [0x33] - cancel upload
+    BLE_IMG_CMD_DELETE = 0x34   // [0x34] - delete existing image
+};
+
+// Image upload status bytes (sent via data status characteristic notifications)
+// Uses 0x30+ range to avoid conflicts with data export status (0x20-0x23)
+enum BLEImageStatus {
+    BLE_IMG_STATUS_IDLE      = 0x30,
+    BLE_IMG_STATUS_READY     = 0x31,
+    BLE_IMG_STATUS_RECEIVING = 0x32,
+    BLE_IMG_STATUS_SUCCESS   = 0x33,
+    BLE_IMG_STATUS_ERROR     = 0x34,
+    BLE_IMG_STATUS_HAS_IMAGE = 0x35  // Sent on connect if image exists
+};
+
+class OTAHandler;  // Forward declaration for OTA active check
+
+/**
+ * ImageUploadHandler - Receives screensaver image data over BLE
+ * and writes it to LittleFS as a raw RGB565 file.
+ *
+ * Protocol mirrors the OTA pattern: START -> DATA chunks -> END
+ * Image is written to a temp file first, then renamed on success.
+ */
+class ImageUploadHandler {
+public:
+    ImageUploadHandler();
+
+    void init(OTAHandler* ota);
+
+    /**
+     * Start a new image upload.
+     * @param file_size Expected size in bytes (must be BLE_IMAGE_EXPECTED_SIZE)
+     * @return true if upload started successfully
+     */
+    bool start_upload(uint32_t file_size);
+
+    /**
+     * Process a chunk of image data.
+     * @param data Pointer to chunk data
+     * @param size Size of chunk in bytes
+     * @return true if chunk written successfully
+     */
+    bool process_chunk(const uint8_t* data, size_t size);
+
+    /**
+     * Finalize the upload: verify size and rename temp file.
+     * @return true if finalization successful
+     */
+    bool complete_upload();
+
+    /**
+     * Abort an in-progress upload and clean up temp file.
+     */
+    void abort_upload();
+
+    /**
+     * Delete the screensaver image file.
+     * @return true if file deleted or didn't exist
+     */
+    bool delete_image();
+
+    /**
+     * Check if a screensaver image exists on LittleFS.
+     */
+    bool has_image() const;
+
+    uint8_t get_status() const { return current_status_; }
+    float get_progress() const;
+    bool is_upload_active() const { return upload_in_progress_; }
+
+private:
+    OTAHandler* ota_handler_;
+    File temp_file_;
+    uint32_t expected_size_;
+    uint32_t received_size_;
+    bool upload_in_progress_;
+    uint8_t current_status_;
+
+    void cleanup_temp_file();
+};

--- a/src/bluetooth/manager.cpp
+++ b/src/bluetooth/manager.cpp
@@ -63,6 +63,7 @@ BluetoothManager::~BluetoothManager() {
 void BluetoothManager::init(Preferences* prefs) {
     log("Bluetooth: Manager initialized (enable via Developer Mode)\n");
     ota_handler.init(prefs);
+    image_handler.init(&ota_handler);
     // Create UI status queue to marshal UI updates to UI task
     if (!ui_status_queue) {
         ui_status_queue = xQueueCreate(8, sizeof(UIStatusMessage));
@@ -131,7 +132,7 @@ void BluetoothManager::enable(unsigned long timeout_ms) {
     ble_server->setCallbacks(this);
     
     // Create OTA service
-    ota_service = ble_server->createService(BLE_OTA_SERVICE_UUID);
+    ota_service = ble_server->createService(BLEUUID(BLE_OTA_SERVICE_UUID), 12);
     delay(BLE_INIT_SERVICE_DELAY_MS);
     
     ota_data_characteristic = ota_service->createCharacteristic(
@@ -161,8 +162,8 @@ void BluetoothManager::enable(unsigned long timeout_ms) {
     build_number_characteristic->setValue(ota_handler.get_build_number().c_str());
     delay(BLE_INIT_CHARACTERISTIC_DELAY_MS);
     
-    // Create measurement data service
-    data_service = ble_server->createService(BLE_DATA_SERVICE_UUID);
+    // Create data service (also used for image upload)
+    data_service = ble_server->createService(BLEUUID(BLE_DATA_SERVICE_UUID), 12);
     delay(BLE_INIT_SERVICE_DELAY_MS);
     
     data_control_characteristic = data_service->createCharacteristic(
@@ -174,8 +175,9 @@ void BluetoothManager::enable(unsigned long timeout_ms) {
     
     data_transfer_characteristic = data_service->createCharacteristic(
         BLE_DATA_TRANSFER_CHAR_UUID,
-        BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_NOTIFY
+        BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_NOTIFY | BLECharacteristic::PROPERTY_WRITE | BLECharacteristic::PROPERTY_WRITE_NR
     );
+    data_transfer_characteristic->setCallbacks(this);
     delay(BLE_INIT_CHARACTERISTIC_DELAY_MS);
     
     data_status_characteristic = data_service->createCharacteristic(
@@ -185,7 +187,7 @@ void BluetoothManager::enable(unsigned long timeout_ms) {
     delay(BLE_INIT_CHARACTERISTIC_DELAY_MS);
     
     // Create debug service (Nordic UART)
-    debug_service = ble_server->createService(BLE_DEBUG_SERVICE_UUID);
+    debug_service = ble_server->createService(BLEUUID(BLE_DEBUG_SERVICE_UUID), 8);
     delay(BLE_INIT_SERVICE_DELAY_MS);
 
     debug_rx_characteristic = debug_service->createCharacteristic(
@@ -202,7 +204,7 @@ void BluetoothManager::enable(unsigned long timeout_ms) {
     delay(BLE_INIT_CHARACTERISTIC_DELAY_MS);
     
     // Create system info service
-    sysinfo_service = ble_server->createService(BLE_SYSINFO_SERVICE_UUID);
+    sysinfo_service = ble_server->createService(BLEUUID(BLE_SYSINFO_SERVICE_UUID), 15);
     delay(BLE_INIT_SERVICE_DELAY_MS);
     
     sysinfo_system_characteristic = sysinfo_service->createCharacteristic(
@@ -247,7 +249,7 @@ void BluetoothManager::enable(unsigned long timeout_ms) {
     
     sysinfo_service->start();
     delay(BLE_INIT_START_DELAY_MS);
-    
+
     BLEAdvertising* advertising = BLEDevice::getAdvertising();
     advertising->addServiceUUID(BLE_OTA_SERVICE_UUID);
     advertising->addServiceUUID(BLE_DEBUG_SERVICE_UUID);
@@ -300,7 +302,11 @@ void BluetoothManager::disable() {
     if (data_export_in_progress) {
         stop_data_export();
     }
-    
+
+    if (image_handler.is_upload_active()) {
+        image_handler.abort_upload();
+    }
+
     stop_advertising();
     delay(BLE_SHUTDOWN_ADVERTISING_DELAY_MS);
     
@@ -833,6 +839,14 @@ void BluetoothManager::handle_data_control_command(BLECharacteristic* characteri
             }
             break;
             
+        // Image upload commands (0x30+ range) routed through data service
+        case BLE_IMG_CMD_START:
+        case BLE_IMG_CMD_END:
+        case BLE_IMG_CMD_ABORT:
+        case BLE_IMG_CMD_DELETE:
+            handle_image_control_command(command, data);
+            break;
+
         default:
             log("Bluetooth Data: Unknown command: 0x%02X\n", command);
             set_data_status(BLE_DATA_ERROR);
@@ -845,6 +859,13 @@ void BluetoothManager::onConnect(BLEServer* server) {
     device_connected = true;
     log("BLE: Client connected - timeout paused while connected\n");
     mark_sessions_info_dirty();
+
+    // Notify client whether a screensaver image exists (via data status characteristic)
+    if (data_status_characteristic && image_handler.has_image()) {
+        uint8_t status = BLE_IMG_STATUS_HAS_IMAGE;
+        data_status_characteristic->setValue(&status, 1);
+        data_status_characteristic->notify();
+    }
 }
 
 void BluetoothManager::onDisconnect(BLEServer* server) {
@@ -856,13 +877,17 @@ void BluetoothManager::onDisconnect(BLEServer* server) {
     if (ota_handler.is_ota_active()) {
         ota_handler.abort_ota();
     }
-    
+
     if (data_export_in_progress) {
         stop_data_export();
     }
-    
+
+    if (image_handler.is_upload_active()) {
+        image_handler.abort_upload();
+    }
+
     debug_stream_active = false;
-    
+
     // Restart advertising for next connection
     delay(500);
     start_advertising();
@@ -879,6 +904,14 @@ void BluetoothManager::onWrite(BLECharacteristic* characteristic) {
     } else if (characteristic == data_control_characteristic) {
         LOG_BLE("  -> Handling data control\n");
         handle_data_control_command(characteristic);
+    } else if (characteristic == data_transfer_characteristic) {
+        // Image data chunks arrive here (writes to data transfer characteristic)
+        if (image_handler.is_upload_active()) {
+            String value = characteristic->getValue();
+            if (value.length() > 0 && !image_handler.process_chunk((const uint8_t*)value.c_str(), value.length())) {
+                set_image_status(BLE_IMG_STATUS_ERROR);
+            }
+        }
     } else if (characteristic == sysinfo_diagnostics_characteristic) {
         LOG_BLE("  -> QUEUING DIAGNOSTIC REPORT REQUEST\n");
         diagnostic_report_pending = true; // Defer heavy work to bluetooth task context
@@ -889,6 +922,56 @@ void BluetoothManager::onWrite(BLECharacteristic* characteristic) {
 
 void BluetoothManager::onRead(BLECharacteristic* characteristic) {
     // Reserved for future use
+}
+
+void BluetoothManager::handle_image_control_command(uint8_t command, const String& value) {
+    switch (command) {
+        case BLE_IMG_CMD_START: {
+            if (value.length() < 5) {
+                LOG_BLE("Image: START command too short\n");
+                set_image_status(BLE_IMG_STATUS_ERROR);
+                return;
+            }
+            uint32_t file_size = (uint8_t)value[1] |
+                                 ((uint8_t)value[2] << 8) |
+                                 ((uint8_t)value[3] << 16) |
+                                 ((uint8_t)value[4] << 24);
+            if (image_handler.start_upload(file_size)) {
+                set_image_status(BLE_IMG_STATUS_RECEIVING);
+            } else {
+                set_image_status(BLE_IMG_STATUS_ERROR);
+            }
+            break;
+        }
+        case BLE_IMG_CMD_END:
+            if (image_handler.complete_upload()) {
+                set_image_status(BLE_IMG_STATUS_SUCCESS);
+            } else {
+                set_image_status(BLE_IMG_STATUS_ERROR);
+            }
+            break;
+        case BLE_IMG_CMD_ABORT:
+            image_handler.abort_upload();
+            set_image_status(BLE_IMG_STATUS_IDLE);
+            break;
+        case BLE_IMG_CMD_DELETE:
+            if (image_handler.delete_image()) {
+                set_image_status(BLE_IMG_STATUS_IDLE);
+            } else {
+                set_image_status(BLE_IMG_STATUS_ERROR);
+            }
+            break;
+        default:
+            LOG_BLE("Image: Unknown command 0x%02X\n", command);
+            break;
+    }
+}
+
+void BluetoothManager::set_image_status(BLEImageStatus status) {
+    if (!data_status_characteristic) return;
+    uint8_t val = static_cast<uint8_t>(status);
+    data_status_characteristic->setValue(&val, 1);
+    data_status_characteristic->notify();
 }
 
 String BluetoothManager::check_ota_failure_after_boot() {

--- a/src/bluetooth/manager.cpp
+++ b/src/bluetooth/manager.cpp
@@ -7,6 +7,7 @@
 #include <nvs_flash.h>
 #include <nvs.h>
 #include "../system/performance_monitor.h"
+#include "../system/screensaver_settings.h"
 #include "../system/statistics_manager.h"
 #include "../system/diagnostics_controller.h"
 #include "../config/constants.h"
@@ -847,6 +848,11 @@ void BluetoothManager::handle_data_control_command(BLECharacteristic* characteri
             handle_image_control_command(command, data);
             break;
 
+        case BLE_SETTINGS_CMD_GET_SCREENSAVER:
+        case BLE_SETTINGS_CMD_SET_SCREENSAVER:
+            handle_screensaver_settings_command(command, data);
+            break;
+
         default:
             log("Bluetooth Data: Unknown command: 0x%02X\n", command);
             set_data_status(BLE_DATA_ERROR);
@@ -972,6 +978,94 @@ void BluetoothManager::set_image_status(BLEImageStatus status) {
     uint8_t val = static_cast<uint8_t>(status);
     data_status_characteristic->setValue(&val, 1);
     data_status_characteristic->notify();
+}
+
+void BluetoothManager::handle_screensaver_settings_command(uint8_t command, const String& value) {
+    if (is_data_channel_busy_for_settings()) {
+        LOG_BLE("Screensaver settings: rejected command 0x%02X while data channel is busy\n", command);
+        send_screensaver_settings_error(BLE_SETTINGS_ERROR_BUSY);
+        return;
+    }
+
+    switch (command) {
+        case BLE_SETTINGS_CMD_GET_SCREENSAVER:
+            send_screensaver_settings();
+            break;
+
+        case BLE_SETTINGS_CMD_SET_SCREENSAVER: {
+            if (value.length() != 4) {
+                LOG_BLE("Screensaver settings: invalid SET length %d\n",
+                        static_cast<int>(value.length()));
+                send_screensaver_settings_error(BLE_SETTINGS_ERROR_INVALID_LENGTH);
+                return;
+            }
+
+            const auto* data = reinterpret_cast<const uint8_t*>(value.c_str());
+            uint16_t idle_timeout_s = static_cast<uint16_t>(data[1]) |
+                                      (static_cast<uint16_t>(data[2]) << 8);
+            uint8_t startup_timeout_s = data[3];
+
+            if (!ScreensaverSettings::is_valid_idle_timeout(idle_timeout_s) ||
+                !ScreensaverSettings::is_valid_startup_timeout(startup_timeout_s)) {
+                LOG_BLE("Screensaver settings: rejected idle=%u startup=%u\n",
+                        idle_timeout_s, startup_timeout_s);
+                send_screensaver_settings_error(BLE_SETTINGS_ERROR_INVALID_RANGE);
+                return;
+            }
+
+            if (!ScreensaverSettings::save_timing(idle_timeout_s, startup_timeout_s)) {
+                LOG_BLE("Screensaver settings: failed to save timing preferences\n");
+                send_screensaver_settings_error(BLE_SETTINGS_ERROR_STORAGE);
+                return;
+            }
+
+            LOG_BLE("Screensaver settings: saved idle=%us startup=%us\n",
+                    idle_timeout_s, startup_timeout_s);
+            send_screensaver_settings();
+            break;
+        }
+
+        default:
+            send_screensaver_settings_error(BLE_SETTINGS_ERROR_INVALID_RANGE);
+            break;
+    }
+}
+
+void BluetoothManager::send_screensaver_settings() {
+    if (!data_status_characteristic) {
+        return;
+    }
+
+    auto settings = ScreensaverSettings::load_timing();
+    uint8_t payload[4] = {
+        static_cast<uint8_t>(BLE_SETTINGS_STATUS_VALUE),
+        static_cast<uint8_t>(settings.idle_timeout_s & 0xFF),
+        static_cast<uint8_t>((settings.idle_timeout_s >> 8) & 0xFF),
+        settings.startup_timeout_s,
+    };
+
+    data_status_characteristic->setValue(payload, sizeof(payload));
+    data_status_characteristic->notify();
+}
+
+void BluetoothManager::send_screensaver_settings_error(BLEScreensaverSettingsError error) {
+    if (!data_status_characteristic) {
+        return;
+    }
+
+    uint8_t payload[2] = {
+        static_cast<uint8_t>(BLE_SETTINGS_STATUS_ERROR),
+        static_cast<uint8_t>(error),
+    };
+
+    data_status_characteristic->setValue(payload, sizeof(payload));
+    data_status_characteristic->notify();
+}
+
+bool BluetoothManager::is_data_channel_busy_for_settings() const {
+    return ota_handler.is_ota_active() ||
+           data_export_in_progress ||
+           image_handler.is_upload_active();
 }
 
 String BluetoothManager::check_ota_failure_after_boot() {

--- a/src/bluetooth/manager.h
+++ b/src/bluetooth/manager.h
@@ -12,6 +12,7 @@
 #include "../config/constants.h"
 #include "ota_handler.h"
 #include "data_stream.h"
+#include "image_upload_handler.h"
 
 // Forward declaration to avoid circular dependency
 class UIManager;
@@ -94,6 +95,7 @@ private:
     // Component handlers
     OTAHandler ota_handler;
     DataStreamManager data_stream;
+    ImageUploadHandler image_handler;
     
     // Data export state
     bool data_export_in_progress;
@@ -124,6 +126,8 @@ private:
     void handle_ota_data_chunk(BLECharacteristic* characteristic);
     void handle_debug_command(BLECharacteristic* characteristic);
     void handle_data_control_command(BLECharacteristic* characteristic);
+    void handle_image_control_command(uint8_t command, const String& value);
+    void set_image_status(BLEImageStatus status);
     void send_next_data_chunk();
     void send_measurement_count();
     void send_log_message(const char* message);
@@ -181,6 +185,7 @@ public:
     bool is_connected() const { return device_connected; }
     bool is_updating() const { return ota_handler.is_ota_active(); }
     bool is_debug_stream_active() const { return debug_stream_active; }
+    bool has_screensaver_image() const { return image_handler.has_image(); }
     
     /**
      * OTA progress information

--- a/src/bluetooth/manager.h
+++ b/src/bluetooth/manager.h
@@ -47,6 +47,24 @@ enum BLEDataStatus {
     BLE_DATA_ERROR = 0x23
 };
 
+// Screensaver timing settings commands/statuses, multiplexed on the Data service
+enum BLEScreensaverSettingsCommand {
+    BLE_SETTINGS_CMD_GET_SCREENSAVER = 0x40,
+    BLE_SETTINGS_CMD_SET_SCREENSAVER = 0x41
+};
+
+enum BLEScreensaverSettingsStatus {
+    BLE_SETTINGS_STATUS_VALUE = 0x42,
+    BLE_SETTINGS_STATUS_ERROR = 0x44
+};
+
+enum BLEScreensaverSettingsError {
+    BLE_SETTINGS_ERROR_BUSY = 0x01,
+    BLE_SETTINGS_ERROR_INVALID_LENGTH = 0x02,
+    BLE_SETTINGS_ERROR_INVALID_RANGE = 0x03,
+    BLE_SETTINGS_ERROR_STORAGE = 0x04
+};
+
 /**
  * BluetoothManager - Central BLE communication manager
  * 
@@ -128,6 +146,10 @@ private:
     void handle_data_control_command(BLECharacteristic* characteristic);
     void handle_image_control_command(uint8_t command, const String& value);
     void set_image_status(BLEImageStatus status);
+    void handle_screensaver_settings_command(uint8_t command, const String& value);
+    void send_screensaver_settings();
+    void send_screensaver_settings_error(BLEScreensaverSettingsError error);
+    bool is_data_channel_busy_for_settings() const;
     void send_next_data_chunk();
     void send_measurement_count();
     void send_log_message(const char* message);

--- a/src/config/bluetooth.h
+++ b/src/config/bluetooth.h
@@ -51,6 +51,18 @@
 #define BLE_SYSINFO_MAX_PAYLOAD_BYTES 512                                       // Maximum payload size for system info
 
 //------------------------------------------------------------------------------
+// IMAGE UPLOAD (via Data Service)
+//------------------------------------------------------------------------------
+// Image upload reuses the Data Service to avoid extra BLE heap allocation.
+// Commands use 0x30+ range on the data control characteristic.
+// Image data chunks are written to the data transfer characteristic.
+
+// Image file constants
+#define BLE_IMAGE_EXPECTED_SIZE  255360                                           // 280 * 456 * 2 bytes (RGB565)
+#define BLE_IMAGE_FILENAME       "/screensaver.rgb565"                            // Final image file on LittleFS
+#define BLE_IMAGE_TEMP_FILENAME  "/screensaver.rgb565.tmp"                        // Temp file during upload
+
+//------------------------------------------------------------------------------
 // BLE TIMEOUT SETTINGS
 //------------------------------------------------------------------------------
 #define BLE_AUTO_DISABLE_TIMEOUT_MS (30 * 60 * 1000)                          // Auto-disable BLE after inactivity

--- a/src/hardware/display_manager.cpp
+++ b/src/hardware/display_manager.cpp
@@ -2,6 +2,7 @@
 #include "../config/constants.h"
 #include "../config/logging.h"
 #include <Arduino.h>
+#include <LittleFS.h>
 #include <esp_heap_caps.h>
 #include <algorithm>
 #include <cstring>
@@ -98,6 +99,69 @@ void DisplayManager::update() {
     
     touch_driver.update();
     lv_timer_handler();
+}
+
+bool DisplayManager::draw_rgb565_file(const char* path, uint16_t width, uint16_t height) {
+    if (!initialized || !gfx_device || !path || width == 0 || height == 0) {
+        return false;
+    }
+
+    const size_t expected_size = static_cast<size_t>(width) * height * sizeof(uint16_t);
+    File file = LittleFS.open(path, "r");
+    if (!file) {
+        LOG_BLE("[DISPLAY] RGB565 draw skipped: failed to open %s\n", path);
+        return false;
+    }
+
+    if (file.size() != expected_size) {
+        LOG_BLE("[DISPLAY] RGB565 draw skipped: %s size %u != %u\n",
+                path,
+                static_cast<unsigned>(file.size()),
+                static_cast<unsigned>(expected_size));
+        file.close();
+        return false;
+    }
+
+    uint16_t rows_per_chunk = 16;
+    uint16_t* row_buffer = nullptr;
+    while (rows_per_chunk >= 4 && row_buffer == nullptr) {
+        row_buffer = static_cast<uint16_t*>(
+            heap_caps_aligned_alloc(LV_DRAW_BUF_ALIGN,
+                                    static_cast<size_t>(width) * rows_per_chunk * sizeof(uint16_t),
+                                    MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT));
+        if (!row_buffer) {
+            rows_per_chunk /= 2;
+        }
+    }
+
+    if (!row_buffer) {
+        LOG_BLE("[DISPLAY] RGB565 draw skipped: row buffer allocation failed\n");
+        file.close();
+        return false;
+    }
+
+    const int16_t x = static_cast<int16_t>((screen_width > width) ? ((screen_width - width) / 2) : 0);
+    const int16_t y = static_cast<int16_t>((screen_height > height) ? ((screen_height - height) / 2) : 0);
+    bool success = true;
+
+    for (uint16_t current_y = 0; current_y < height; current_y += rows_per_chunk) {
+        const uint16_t rows = std::min<uint16_t>(rows_per_chunk, height - current_y);
+        const size_t bytes_to_read = static_cast<size_t>(width) * rows * sizeof(uint16_t);
+        const size_t bytes_read = file.read(reinterpret_cast<uint8_t*>(row_buffer), bytes_to_read);
+        if (bytes_read != bytes_to_read) {
+            LOG_BLE("[DISPLAY] RGB565 draw aborted: short read at row %u\n", current_y);
+            success = false;
+            break;
+        }
+
+        // Screensaver uploads are stored as native little-endian RGB565.
+        // Arduino_GFX converts native pixels to the panel byte order here.
+        gfx_device->draw16bitRGBBitmap(x, y + current_y, row_buffer, width, rows);
+    }
+
+    heap_caps_free(row_buffer);
+    file.close();
+    return success;
 }
 
 // Update the refresh area to be full width

--- a/src/hardware/display_manager.h
+++ b/src/hardware/display_manager.h
@@ -24,6 +24,7 @@ public:
     void init();
     void update();
     void set_brightness(float brightness);
+    bool draw_rgb565_file(const char* path, uint16_t width, uint16_t height);
     
     uint32_t get_width() const { return screen_width; }
     uint32_t get_height() const { return screen_height; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <LittleFS.h>
+#include <Preferences.h>
 #include <esp_system.h>
 #include "hardware/hardware_manager.h"
 #include "system/state_machine.h"
@@ -8,6 +9,7 @@
 #include "controllers/grind_controller.h"
 #include "ui/ui_manager.h"
 #include "config/constants.h"
+#include "system/screensaver_settings.h"
 #include "bluetooth/manager.h"
 #include "tasks/task_manager.h"
 #include "tasks/weight_sampling_task.h"
@@ -30,6 +32,45 @@ static uint32_t core1_cycle_time_min_ms = UINT32_MAX;
 static uint32_t core1_cycle_time_max_ms = 0;
 static uint32_t core1_last_heartbeat_time = 0;
 #endif
+
+namespace {
+
+float load_startup_display_brightness() {
+    Preferences prefs;
+    float brightness = USER_SCREEN_BRIGHTNESS_NORMAL;
+    if (prefs.begin("brightness", true)) {
+        brightness = prefs.getFloat("normal", USER_SCREEN_BRIGHTNESS_NORMAL);
+        prefs.end();
+    }
+
+    if (brightness < 0.15f) {
+        brightness = 0.15f;
+    }
+    return brightness;
+}
+
+void draw_early_startup_splash_if_ready() {
+    if (!state_machine.is_state(UIState::READY) ||
+        !ScreensaverSettings::is_startup_enabled() ||
+        !LittleFS.exists(BLE_IMAGE_FILENAME)) {
+        return;
+    }
+
+    DisplayManager* display = hardware_manager.get_display();
+    if (!display || !display->is_initialized()) {
+        return;
+    }
+
+    display->set_brightness(load_startup_display_brightness());
+
+    if (display->draw_rgb565_file(BLE_IMAGE_FILENAME,
+                                  HW_DISPLAY_WIDTH_PX,
+                                  HW_DISPLAY_HEIGHT_PX)) {
+        LOG_BLE("[STARTUP] Early screensaver splash drawn\n");
+    }
+}
+
+}  // namespace
 
 void setup() {
     Serial.begin(HW_SERIAL_BAUD_RATE);
@@ -92,6 +133,8 @@ void setup() {
     } else {
         state_machine.init(UIState::READY);
     }
+
+    draw_early_startup_splash_if_ready();
     
     ui_manager.init(&hardware_manager, &state_machine, &profile_controller, &grind_controller, &bluetooth_manager);
     

--- a/src/system/screensaver_settings.cpp
+++ b/src/system/screensaver_settings.cpp
@@ -1,0 +1,75 @@
+#include "screensaver_settings.h"
+
+#include <Preferences.h>
+#include <algorithm>
+
+namespace {
+
+constexpr const char* kPrefsNamespace = "screensaver";
+constexpr const char* kIdleTimeoutKey = "idle_timeout_s";
+constexpr const char* kStartupTimeoutKey = "startup_s";
+
+}  // namespace
+
+namespace ScreensaverSettings {
+
+bool is_valid_idle_timeout(uint16_t idle_timeout_s) {
+    return idle_timeout_s >= kMinIdleTimeoutS && idle_timeout_s <= kMaxIdleTimeoutS;
+}
+
+bool is_valid_startup_timeout(uint8_t startup_timeout_s) {
+    return startup_timeout_s >= kMinStartupTimeoutS && startup_timeout_s <= kMaxStartupTimeoutS;
+}
+
+ScreensaverTimingSettings load_timing() {
+    Preferences prefs;
+    ScreensaverTimingSettings settings{
+        kDefaultIdleTimeoutS,
+        kDefaultStartupTimeoutS,
+    };
+
+    if (!prefs.begin(kPrefsNamespace, true)) {
+        return settings;
+    }
+
+    settings.idle_timeout_s = prefs.getUShort(kIdleTimeoutKey, kDefaultIdleTimeoutS);
+    settings.startup_timeout_s = prefs.getUChar(kStartupTimeoutKey, kDefaultStartupTimeoutS);
+    prefs.end();
+
+    if (!is_valid_idle_timeout(settings.idle_timeout_s)) {
+        settings.idle_timeout_s = kDefaultIdleTimeoutS;
+    }
+    if (!is_valid_startup_timeout(settings.startup_timeout_s)) {
+        settings.startup_timeout_s = kDefaultStartupTimeoutS;
+    }
+
+    return settings;
+}
+
+bool save_timing(uint16_t idle_timeout_s, uint8_t startup_timeout_s) {
+    if (!is_valid_idle_timeout(idle_timeout_s) ||
+        !is_valid_startup_timeout(startup_timeout_s)) {
+        return false;
+    }
+
+    Preferences prefs;
+    if (!prefs.begin(kPrefsNamespace, false)) {
+        return false;
+    }
+
+    size_t idle_written = prefs.putUShort(kIdleTimeoutKey, idle_timeout_s);
+    size_t startup_written = prefs.putUChar(kStartupTimeoutKey, startup_timeout_s);
+    prefs.end();
+
+    return idle_written == sizeof(uint16_t) && startup_written == sizeof(uint8_t);
+}
+
+uint32_t idle_timeout_ms(const ScreensaverTimingSettings& settings) {
+    return static_cast<uint32_t>(settings.idle_timeout_s) * 1000U;
+}
+
+uint32_t weight_activity_window_ms(const ScreensaverTimingSettings& settings) {
+    return std::min(idle_timeout_ms(settings), kWeightActivityWindowCapMs);
+}
+
+}  // namespace ScreensaverSettings

--- a/src/system/screensaver_settings.cpp
+++ b/src/system/screensaver_settings.cpp
@@ -8,6 +8,18 @@ namespace {
 constexpr const char* kPrefsNamespace = "screensaver";
 constexpr const char* kIdleTimeoutKey = "idle_timeout_s";
 constexpr const char* kStartupTimeoutKey = "startup_s";
+constexpr const char* kStartupEnabledKey = "startup";
+constexpr const char* kSleepEnabledKey = "sleep";
+
+bool get_bool_setting(const char* key, bool default_value) {
+    Preferences prefs;
+    if (!prefs.begin(kPrefsNamespace, true)) {
+        return default_value;
+    }
+    bool value = prefs.getBool(key, default_value);
+    prefs.end();
+    return value;
+}
 
 }  // namespace
 
@@ -19,6 +31,14 @@ bool is_valid_idle_timeout(uint16_t idle_timeout_s) {
 
 bool is_valid_startup_timeout(uint8_t startup_timeout_s) {
     return startup_timeout_s >= kMinStartupTimeoutS && startup_timeout_s <= kMaxStartupTimeoutS;
+}
+
+bool is_startup_enabled() {
+    return get_bool_setting(kStartupEnabledKey, false);
+}
+
+bool is_sleep_enabled() {
+    return get_bool_setting(kSleepEnabledKey, false);
 }
 
 ScreensaverTimingSettings load_timing() {

--- a/src/system/screensaver_settings.h
+++ b/src/system/screensaver_settings.h
@@ -24,6 +24,8 @@ ScreensaverTimingSettings load_timing();
 bool save_timing(uint16_t idle_timeout_s, uint8_t startup_timeout_s);
 bool is_valid_idle_timeout(uint16_t idle_timeout_s);
 bool is_valid_startup_timeout(uint8_t startup_timeout_s);
+bool is_startup_enabled();
+bool is_sleep_enabled();
 uint32_t idle_timeout_ms(const ScreensaverTimingSettings& settings);
 uint32_t weight_activity_window_ms(const ScreensaverTimingSettings& settings);
 

--- a/src/system/screensaver_settings.h
+++ b/src/system/screensaver_settings.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include "../config/constants.h"
+
+struct ScreensaverTimingSettings {
+    uint16_t idle_timeout_s;
+    uint8_t startup_timeout_s;
+};
+
+namespace ScreensaverSettings {
+
+constexpr uint16_t kDefaultIdleTimeoutS = USER_SCREEN_AUTO_DIM_TIMEOUT_MS / 1000;
+constexpr uint8_t kDefaultStartupTimeoutS = 3;
+
+constexpr uint16_t kMinIdleTimeoutS = 30;
+constexpr uint16_t kMaxIdleTimeoutS = 3600;
+constexpr uint8_t kMinStartupTimeoutS = 1;
+constexpr uint8_t kMaxStartupTimeoutS = 30;
+
+constexpr uint32_t kWeightActivityWindowCapMs = 60000;
+
+ScreensaverTimingSettings load_timing();
+bool save_timing(uint16_t idle_timeout_s, uint8_t startup_timeout_s);
+bool is_valid_idle_timeout(uint16_t idle_timeout_s);
+bool is_valid_startup_timeout(uint8_t startup_timeout_s);
+uint32_t idle_timeout_ms(const ScreensaverTimingSettings& settings);
+uint32_t weight_activity_window_ms(const ScreensaverTimingSettings& settings);
+
+}  // namespace ScreensaverSettings

--- a/src/ui/controllers/menu_controller.cpp
+++ b/src/ui/controllers/menu_controller.cpp
@@ -60,6 +60,9 @@ void MenuUIController::register_events() {
     EventBridgeLVGL::register_handler(ET::BRIGHTNESS_SCREENSAVER_SLIDER, [this](lv_event_t*) { handle_brightness_screensaver_slider(); });
     EventBridgeLVGL::register_handler(ET::BRIGHTNESS_SCREENSAVER_SLIDER_RELEASED, [this](lv_event_t*) { handle_brightness_screensaver_slider_released(); });
 
+    EventBridgeLVGL::register_handler(ET::SCREENSAVER_STARTUP_TOGGLE, [this](lv_event_t*) { handle_screensaver_startup_toggle(); });
+    EventBridgeLVGL::register_handler(ET::SCREENSAVER_SLEEP_TOGGLE, [this](lv_event_t*) { handle_screensaver_sleep_toggle(); });
+
     // Note: Event registration for menu widgets is done in the page creation functions
     // (menu_screen.cpp) because the menu is created lazily and destroyed on hide.
     // Attempting to register events here would fail silently since widgets don't exist yet.
@@ -559,6 +562,31 @@ void MenuUIController::handle_brightness_screensaver_slider_released() {
     float normal = get_normal_brightness();
     ui_manager_->get_hardware_manager()->get_display()->set_brightness(normal);
     LOG_DEBUG_PRINTF("Touch released - restored normal brightness to %.2f\n", normal);
+}
+
+void MenuUIController::handle_screensaver_startup_toggle() {
+    auto* toggle = ui_manager_->menu_screen.get_screensaver_startup_toggle();
+    if (!toggle) return;
+
+    bool enabled = lv_obj_has_state(toggle, LV_STATE_CHECKED);
+    Preferences prefs;
+    prefs.begin("screensaver", false);
+    prefs.putBool("startup", enabled);
+    prefs.end();
+
+    LOG_BLE("Screensaver startup: %s\n", enabled ? "enabled" : "disabled");
+}
+
+void MenuUIController::handle_screensaver_sleep_toggle() {
+    auto* toggle = ui_manager_->menu_screen.get_screensaver_sleep_toggle();
+    if (!toggle) return;
+
+    bool enabled = lv_obj_has_state(toggle, LV_STATE_CHECKED);
+    Preferences prefs;
+    prefs.begin("screensaver", false);
+    prefs.putBool("sleep", enabled);
+    prefs.end();
+
 }
 
 void MenuUIController::perform_factory_reset() {

--- a/src/ui/controllers/menu_controller.h
+++ b/src/ui/controllers/menu_controller.h
@@ -37,6 +37,8 @@ public:
     void handle_brightness_normal_slider_released();
     void handle_brightness_screensaver_slider();
     void handle_brightness_screensaver_slider_released();
+    void handle_screensaver_startup_toggle();
+    void handle_screensaver_sleep_toggle();
 
     float get_normal_brightness() const;
     float get_screensaver_brightness() const;

--- a/src/ui/controllers/screen_timeout_controller.cpp
+++ b/src/ui/controllers/screen_timeout_controller.cpp
@@ -1,4 +1,5 @@
 #include "screen_timeout_controller.h"
+#include "screensaver_controller.h"
 
 #include "../../config/constants.h"
 #include "../../hardware/display_manager.h"
@@ -32,6 +33,9 @@ void ScreenTimeoutController::update() {
 
     if (ui_manager_->state_machine && ui_manager_->state_machine->is_state(UIState::GRINDING)) {
         if (screen_dimmed_) {
+            if (screensaver_controller_ && screensaver_controller_->is_visible()) {
+                screensaver_controller_->hide();
+            }
             float normal = USER_SCREEN_BRIGHTNESS_NORMAL;
             if (ui_manager_->menu_controller_) {
                 normal = ui_manager_->menu_controller_->get_normal_brightness();
@@ -57,7 +61,19 @@ void ScreenTimeoutController::update() {
         }
         display->set_brightness(dimmed);
         screen_dimmed_ = true;
+
+        // Show screensaver image if enabled
+        if (screensaver_controller_ &&
+            screensaver_controller_->is_sleep_enabled() &&
+            screensaver_controller_->has_image()) {
+            screensaver_controller_->show();
+        }
     } else if (!should_dim && screen_dimmed_) {
+        // Hide screensaver before restoring brightness
+        if (screensaver_controller_ && screensaver_controller_->is_visible()) {
+            screensaver_controller_->hide();
+        }
+
         float normal = USER_SCREEN_BRIGHTNESS_NORMAL;
         if (ui_manager_->menu_controller_) {
             normal = ui_manager_->menu_controller_->get_normal_brightness();

--- a/src/ui/controllers/screen_timeout_controller.cpp
+++ b/src/ui/controllers/screen_timeout_controller.cpp
@@ -1,13 +1,17 @@
 #include "screen_timeout_controller.h"
 #include "screensaver_controller.h"
 
+#include <Arduino.h>
+
 #include "../../config/constants.h"
 #include "../../hardware/display_manager.h"
 #include "../../hardware/hardware_manager.h"
 #include "../ui_manager.h"
 
 ScreenTimeoutController::ScreenTimeoutController(UIManager* manager)
-    : ui_manager_(manager), screen_dimmed_(false) {}
+    : ui_manager_(manager)
+    , timing_settings_(ScreensaverSettings::load_timing())
+    , screen_dimmed_(false) {}
 
 void ScreenTimeoutController::register_events() {}
 
@@ -26,33 +30,29 @@ void ScreenTimeoutController::update() {
         return;
     }
 
+    if (is_protected_state()) {
+        restore_normal_display(display);
+        return;
+    }
+
+    uint32_t now = millis();
+    refresh_settings_if_needed(now);
+
     auto* touch_driver = display->get_touch_driver();
     if (!touch_driver) {
         return;
     }
 
-    if (ui_manager_->state_machine && ui_manager_->state_machine->is_state(UIState::GRINDING)) {
-        if (screen_dimmed_) {
-            if (screensaver_controller_ && screensaver_controller_->is_visible()) {
-                screensaver_controller_->hide();
-            }
-            float normal = USER_SCREEN_BRIGHTNESS_NORMAL;
-            if (ui_manager_->menu_controller_) {
-                normal = ui_manager_->menu_controller_->get_normal_brightness();
-            }
-            display->set_brightness(normal);
-            screen_dimmed_ = false;
-        }
-        return;
-    }
-
     uint32_t ms_since_touch = touch_driver->get_ms_since_last_touch();
     auto* sensor = hardware->get_weight_sensor();
+    uint32_t idle_timeout_ms = ScreensaverSettings::idle_timeout_ms(timing_settings_);
+    uint32_t weight_activity_window_ms =
+        ScreensaverSettings::weight_activity_window_ms(timing_settings_);
     bool recent_weight_activity = sensor &&
-                                  sensor->weight_range_exceeds(USER_SCREEN_AUTO_DIM_TIMEOUT_MS,
+                                  sensor->weight_range_exceeds(weight_activity_window_ms,
                                                                USER_WEIGHT_ACTIVITY_THRESHOLD_G);
 
-    bool should_dim = (ms_since_touch >= USER_SCREEN_AUTO_DIM_TIMEOUT_MS) && !recent_weight_activity;
+    bool should_dim = (ms_since_touch >= idle_timeout_ms) && !recent_weight_activity;
 
     if (should_dim && !screen_dimmed_) {
         float dimmed = USER_SCREEN_BRIGHTNESS_DIMMED;
@@ -69,16 +69,56 @@ void ScreenTimeoutController::update() {
             screensaver_controller_->show();
         }
     } else if (!should_dim && screen_dimmed_) {
-        // Hide screensaver before restoring brightness
-        if (screensaver_controller_ && screensaver_controller_->is_visible()) {
-            screensaver_controller_->hide();
-        }
+        restore_normal_display(display);
+    }
+}
 
+void ScreenTimeoutController::refresh_settings_if_needed(uint32_t now_ms) {
+    constexpr uint32_t kRefreshIntervalMs = 5000;
+
+    if (last_settings_refresh_ms_ != 0 &&
+        now_ms - last_settings_refresh_ms_ < kRefreshIntervalMs) {
+        return;
+    }
+
+    timing_settings_ = ScreensaverSettings::load_timing();
+    last_settings_refresh_ms_ = now_ms;
+}
+
+void ScreenTimeoutController::restore_normal_display(DisplayManager* display) {
+    bool screensaver_visible = screensaver_controller_ && screensaver_controller_->is_visible();
+    if (screensaver_visible) {
+        screensaver_controller_->hide();
+    }
+
+    if (screen_dimmed_ || screensaver_visible) {
         float normal = USER_SCREEN_BRIGHTNESS_NORMAL;
-        if (ui_manager_->menu_controller_) {
+        if (ui_manager_ && ui_manager_->menu_controller_) {
             normal = ui_manager_->menu_controller_->get_normal_brightness();
         }
         display->set_brightness(normal);
-        screen_dimmed_ = false;
     }
+
+    screen_dimmed_ = false;
+}
+
+bool ScreenTimeoutController::is_protected_state() const {
+    if (!ui_manager_) {
+        return false;
+    }
+
+    bool ota_active = ui_manager_->bluetooth_manager &&
+                      ui_manager_->bluetooth_manager->is_updating();
+    if (ota_active) {
+        return true;
+    }
+
+    if (!ui_manager_->state_machine) {
+        return false;
+    }
+
+    UIState state = ui_manager_->state_machine->get_current_state();
+    return state == UIState::GRINDING ||
+           state == UIState::OTA_UPDATE ||
+           state == UIState::OTA_UPDATE_FAILED;
 }

--- a/src/ui/controllers/screen_timeout_controller.h
+++ b/src/ui/controllers/screen_timeout_controller.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 class UIManager;
+class ScreensaverController;
 
 // Implements automatic screen dimming based on touch/weight activity
 
@@ -13,7 +14,12 @@ public:
     void register_events();
     void update();
 
+    void set_screensaver_controller(ScreensaverController* controller) {
+        screensaver_controller_ = controller;
+    }
+
 private:
     UIManager* ui_manager_;
+    ScreensaverController* screensaver_controller_ = nullptr;
     bool screen_dimmed_;
 };

--- a/src/ui/controllers/screen_timeout_controller.h
+++ b/src/ui/controllers/screen_timeout_controller.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#include "../../system/screensaver_settings.h"
 
 class UIManager;
 class ScreensaverController;
+class DisplayManager;
 
 // Implements automatic screen dimming based on touch/weight activity
 
@@ -19,7 +21,13 @@ public:
     }
 
 private:
+    void refresh_settings_if_needed(uint32_t now_ms);
+    void restore_normal_display(DisplayManager* display);
+    bool is_protected_state() const;
+
     UIManager* ui_manager_;
     ScreensaverController* screensaver_controller_ = nullptr;
+    ScreensaverTimingSettings timing_settings_;
+    uint32_t last_settings_refresh_ms_ = 0;
     bool screen_dimmed_;
 };

--- a/src/ui/controllers/screensaver_controller.cpp
+++ b/src/ui/controllers/screensaver_controller.cpp
@@ -1,0 +1,157 @@
+#include "screensaver_controller.h"
+#include "../../config/constants.h"
+#include "../../config/logging.h"
+#include <LittleFS.h>
+#include <Preferences.h>
+#include <esp_heap_caps.h>
+
+ScreensaverController::ScreensaverController()
+    : overlay_screen_(nullptr)
+    , previous_screen_(nullptr)
+    , image_widget_(nullptr)
+    , image_buffer_(nullptr)
+    , visible_(false) {
+    memset(&image_dsc_, 0, sizeof(image_dsc_));
+}
+
+ScreensaverController::~ScreensaverController() {
+    hide();
+}
+
+bool ScreensaverController::has_image() const {
+    return LittleFS.exists(BLE_IMAGE_FILENAME);
+}
+
+bool ScreensaverController::is_startup_enabled() const {
+    Preferences prefs;
+    prefs.begin("screensaver", true);
+    bool enabled = prefs.getBool("startup", false);
+    prefs.end();
+    return enabled;
+}
+
+bool ScreensaverController::is_sleep_enabled() const {
+    Preferences prefs;
+    prefs.begin("screensaver", true);
+    bool enabled = prefs.getBool("sleep", false);
+    prefs.end();
+    return enabled;
+}
+
+void ScreensaverController::show() {
+    if (visible_) return;
+    if (!has_image()) return;
+
+    if (!load_image()) {
+        return;
+    }
+
+    // Save the current active screen so we can restore it on hide().
+    // Screens in this project are created once and never deleted, so
+    // this pointer remains valid for the lifetime of the application.
+    previous_screen_ = lv_scr_act();
+
+    // Create a new screen for the overlay
+    overlay_screen_ = lv_obj_create(nullptr);
+    if (!overlay_screen_) {
+        free_image();
+        return;
+    }
+    lv_obj_set_style_bg_color(overlay_screen_, lv_color_hex(0x000000), 0);
+    lv_obj_set_style_bg_opa(overlay_screen_, LV_OPA_COVER, 0);
+
+    // Create image widget filling the screen
+    image_widget_ = lv_img_create(overlay_screen_);
+    if (!image_widget_) {
+        lv_obj_delete(overlay_screen_);
+        overlay_screen_ = nullptr;
+        free_image();
+        return;
+    }
+
+    // Set up image descriptor for raw RGB565 data
+    image_dsc_.header.cf = LV_COLOR_FORMAT_RGB565;
+    image_dsc_.header.w = HW_DISPLAY_WIDTH_PX;
+    image_dsc_.header.h = HW_DISPLAY_HEIGHT_PX;
+    image_dsc_.data_size = BLE_IMAGE_EXPECTED_SIZE;
+    image_dsc_.data = image_buffer_;
+
+    lv_img_set_src(image_widget_, &image_dsc_);
+    lv_obj_center(image_widget_);
+
+    // Tap anywhere to dismiss
+    lv_obj_add_flag(overlay_screen_, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_event_cb(overlay_screen_, touch_dismiss_cb, LV_EVENT_CLICKED, this);
+
+    // Load the overlay screen
+    lv_screen_load(overlay_screen_);
+    visible_ = true;
+}
+
+void ScreensaverController::hide() {
+    if (!visible_) return;
+
+    // Restore the previous active screen before deleting the overlay.
+    if (previous_screen_) {
+        lv_screen_load(previous_screen_);
+        previous_screen_ = nullptr;
+    }
+
+    if (overlay_screen_) {
+        lv_obj_delete(overlay_screen_);
+        overlay_screen_ = nullptr;
+        image_widget_ = nullptr;
+    }
+
+    free_image();
+    visible_ = false;
+}
+
+bool ScreensaverController::load_image() {
+    image_buffer_ = (uint8_t*)heap_caps_malloc(BLE_IMAGE_EXPECTED_SIZE,
+                                                MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!image_buffer_) {
+        LOG_BLE("Screensaver: PSRAM allocation failed (%d bytes)\n", BLE_IMAGE_EXPECTED_SIZE);
+        return false;
+    }
+
+    File f = LittleFS.open(BLE_IMAGE_FILENAME, "r");
+    if (!f) {
+        LOG_BLE("Screensaver: Failed to open image file\n");
+        free_image();
+        return false;
+    }
+
+    size_t total_read = 0;
+    const size_t chunk_size = 4096;
+    while (total_read < BLE_IMAGE_EXPECTED_SIZE) {
+        size_t to_read = std::min(chunk_size, (size_t)(BLE_IMAGE_EXPECTED_SIZE - total_read));
+        size_t bytes_read = f.read(image_buffer_ + total_read, to_read);
+        if (bytes_read == 0) break;
+        total_read += bytes_read;
+    }
+    f.close();
+
+    if (total_read != BLE_IMAGE_EXPECTED_SIZE) {
+        LOG_BLE("Screensaver: Image file size mismatch (%u != %d)\n",
+                (unsigned)total_read, BLE_IMAGE_EXPECTED_SIZE);
+        free_image();
+        return false;
+    }
+
+    return true;
+}
+
+void ScreensaverController::free_image() {
+    if (image_buffer_) {
+        heap_caps_free(image_buffer_);
+        image_buffer_ = nullptr;
+    }
+}
+
+void ScreensaverController::touch_dismiss_cb(lv_event_t* e) {
+    auto* self = static_cast<ScreensaverController*>(lv_event_get_user_data(e));
+    if (self) {
+        self->hide();
+    }
+}

--- a/src/ui/controllers/screensaver_controller.cpp
+++ b/src/ui/controllers/screensaver_controller.cpp
@@ -79,10 +79,6 @@ void ScreensaverController::show() {
     lv_img_set_src(image_widget_, &image_dsc_);
     lv_obj_center(image_widget_);
 
-    // Tap anywhere to dismiss
-    lv_obj_add_flag(overlay_screen_, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_add_event_cb(overlay_screen_, touch_dismiss_cb, LV_EVENT_CLICKED, this);
-
     // Load the overlay screen
     lv_screen_load(overlay_screen_);
     visible_ = true;
@@ -149,9 +145,3 @@ void ScreensaverController::free_image() {
     }
 }
 
-void ScreensaverController::touch_dismiss_cb(lv_event_t* e) {
-    auto* self = static_cast<ScreensaverController*>(lv_event_get_user_data(e));
-    if (self) {
-        self->hide();
-    }
-}

--- a/src/ui/controllers/screensaver_controller.cpp
+++ b/src/ui/controllers/screensaver_controller.cpp
@@ -1,6 +1,8 @@
 #include "screensaver_controller.h"
 #include "../../config/constants.h"
 #include "../../config/logging.h"
+#include <algorithm>
+#include <cstring>
 #include <LittleFS.h>
 #include <Preferences.h>
 #include <esp_heap_caps.h>

--- a/src/ui/controllers/screensaver_controller.cpp
+++ b/src/ui/controllers/screensaver_controller.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <cstring>
 #include <LittleFS.h>
-#include <Preferences.h>
 #include <esp_heap_caps.h>
 
 ScreensaverController::ScreensaverController()
@@ -26,19 +25,11 @@ bool ScreensaverController::has_image() const {
 }
 
 bool ScreensaverController::is_startup_enabled() const {
-    Preferences prefs;
-    prefs.begin("screensaver", true);
-    bool enabled = prefs.getBool("startup", false);
-    prefs.end();
-    return enabled;
+    return ScreensaverSettings::is_startup_enabled();
 }
 
 bool ScreensaverController::is_sleep_enabled() const {
-    Preferences prefs;
-    prefs.begin("screensaver", true);
-    bool enabled = prefs.getBool("sleep", false);
-    prefs.end();
-    return enabled;
+    return ScreensaverSettings::is_sleep_enabled();
 }
 
 uint32_t ScreensaverController::get_startup_timeout_ms() const {

--- a/src/ui/controllers/screensaver_controller.cpp
+++ b/src/ui/controllers/screensaver_controller.cpp
@@ -1,6 +1,7 @@
 #include "screensaver_controller.h"
 #include "../../config/constants.h"
 #include "../../config/logging.h"
+#include "../../system/screensaver_settings.h"
 #include <algorithm>
 #include <cstring>
 #include <LittleFS.h>
@@ -38,6 +39,11 @@ bool ScreensaverController::is_sleep_enabled() const {
     bool enabled = prefs.getBool("sleep", false);
     prefs.end();
     return enabled;
+}
+
+uint32_t ScreensaverController::get_startup_timeout_ms() const {
+    auto settings = ScreensaverSettings::load_timing();
+    return static_cast<uint32_t>(settings.startup_timeout_s) * 1000U;
 }
 
 void ScreensaverController::show() {
@@ -146,4 +152,3 @@ void ScreensaverController::free_image() {
         image_buffer_ = nullptr;
     }
 }
-

--- a/src/ui/controllers/screensaver_controller.h
+++ b/src/ui/controllers/screensaver_controller.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <lvgl.h>
+#include <cstdint>
+
+/**
+ * ScreensaverController - Loads and displays a custom screensaver image
+ * from LittleFS as a full-screen LVGL overlay.
+ *
+ * Used for startup splash and power-save display modes.
+ */
+class ScreensaverController {
+public:
+    ScreensaverController();
+    ~ScreensaverController();
+
+    /// Check if a screensaver image file exists on LittleFS
+    bool has_image() const;
+
+    /// Read NVS preference: show image on startup
+    bool is_startup_enabled() const;
+
+    /// Read NVS preference: show image during sleep/dim
+    bool is_sleep_enabled() const;
+
+    /// Load image from LittleFS and display as full-screen overlay
+    void show();
+
+    /// Hide overlay and free image buffer
+    void hide();
+
+    bool is_visible() const { return visible_; }
+
+private:
+    lv_obj_t* overlay_screen_;
+    lv_obj_t* previous_screen_;
+    lv_obj_t* image_widget_;
+    uint8_t* image_buffer_;
+    lv_image_dsc_t image_dsc_;
+    bool visible_;
+
+    bool load_image();
+    void free_image();
+    static void touch_dismiss_cb(lv_event_t* e);
+};

--- a/src/ui/controllers/screensaver_controller.h
+++ b/src/ui/controllers/screensaver_controller.h
@@ -41,5 +41,4 @@ private:
 
     bool load_image();
     void free_image();
-    static void touch_dismiss_cb(lv_event_t* e);
 };

--- a/src/ui/controllers/screensaver_controller.h
+++ b/src/ui/controllers/screensaver_controller.h
@@ -23,6 +23,9 @@ public:
     /// Read NVS preference: show image during sleep/dim
     bool is_sleep_enabled() const;
 
+    /// Read NVS preference: startup display duration in milliseconds
+    uint32_t get_startup_timeout_ms() const;
+
     /// Load image from LittleFS and display as full-screen overlay
     void show();
 

--- a/src/ui/event_bridge_lvgl.h
+++ b/src/ui/event_bridge_lvgl.h
@@ -51,6 +51,8 @@ public:
         CONFIRM,
         CONFIRM_CANCEL,
         PURGE_CONFIRM_CONTINUE,
+        SCREENSAVER_STARTUP_TOGGLE,
+        SCREENSAVER_SLEEP_TOGGLE,
         COUNT
     };
 

--- a/src/ui/screens/menu_screen.cpp
+++ b/src/ui/screens/menu_screen.cpp
@@ -1,6 +1,8 @@
 #include "menu_screen.h"
 #include <Arduino.h>
 #include <algorithm>
+#include <LittleFS.h>
+#include <Preferences.h>
 #include "../../config/constants.h"
 #include "../../logging/grind_logging.h"
 #include "../../system/statistics_manager.h"
@@ -318,6 +320,22 @@ void MenuScreen::create_display_page(lv_obj_t* parent) {
         lv_obj_add_event_cb(brightness_screensaver_slider, EventBridgeLVGL::dispatch_event, LV_EVENT_RELEASED,
                            reinterpret_cast<void*>(static_cast<intptr_t>(ET::BRIGHTNESS_SCREENSAVER_SLIDER_RELEASED)));
     }
+
+    // Custom screensaver image toggles
+    create_separator(parent, "Custom Image");
+    create_description_label(parent, "Show uploaded image on startup or when display dims.");
+    create_toggle_row(parent, "Startup", &screensaver_startup_toggle);
+    create_toggle_row(parent, "Sleep", &screensaver_sleep_toggle);
+
+    if (screensaver_startup_toggle) {
+        lv_obj_add_event_cb(screensaver_startup_toggle, EventBridgeLVGL::dispatch_event, LV_EVENT_VALUE_CHANGED,
+                           reinterpret_cast<void*>(static_cast<intptr_t>(ET::SCREENSAVER_STARTUP_TOGGLE)));
+    }
+    if (screensaver_sleep_toggle) {
+        lv_obj_add_event_cb(screensaver_sleep_toggle, EventBridgeLVGL::dispatch_event, LV_EVENT_VALUE_CHANGED,
+                           reinterpret_cast<void*>(static_cast<intptr_t>(ET::SCREENSAVER_SLEEP_TOGGLE)));
+    }
+
 }
 
 
@@ -617,6 +635,7 @@ void MenuScreen::show() {
     update_bluetooth_startup_toggle();
     update_logging_toggle();
     update_grind_mode_toggles();
+    update_screensaver_toggles();
 
     LOG_BLE("[%lums MENU] Menu screen shown successfully\n", millis());
 }
@@ -907,6 +926,44 @@ void MenuScreen::update_grind_freshness_hours_label(float hours) {
         }
         lv_label_set_text(grind_freshness_hours_label, buffer);
     }
+}
+
+void MenuScreen::update_screensaver_toggles() {
+    bool image_exists = LittleFS.exists(BLE_IMAGE_FILENAME);
+
+    Preferences prefs;
+    prefs.begin("screensaver", true);
+    bool startup_on = prefs.getBool("startup", false);
+    bool sleep_on = prefs.getBool("sleep", false);
+    prefs.end();
+
+    if (screensaver_startup_toggle) {
+        if (startup_on && image_exists) {
+            lv_obj_add_state(screensaver_startup_toggle, LV_STATE_CHECKED);
+        } else {
+            lv_obj_clear_state(screensaver_startup_toggle, LV_STATE_CHECKED);
+        }
+        // Disable toggles if no image is uploaded
+        if (image_exists) {
+            lv_obj_clear_state(screensaver_startup_toggle, LV_STATE_DISABLED);
+        } else {
+            lv_obj_add_state(screensaver_startup_toggle, LV_STATE_DISABLED);
+        }
+    }
+
+    if (screensaver_sleep_toggle) {
+        if (sleep_on && image_exists) {
+            lv_obj_add_state(screensaver_sleep_toggle, LV_STATE_CHECKED);
+        } else {
+            lv_obj_clear_state(screensaver_sleep_toggle, LV_STATE_CHECKED);
+        }
+        if (image_exists) {
+            lv_obj_clear_state(screensaver_sleep_toggle, LV_STATE_DISABLED);
+        } else {
+            lv_obj_add_state(screensaver_sleep_toggle, LV_STATE_DISABLED);
+        }
+    }
+
 }
 
 lv_obj_t* MenuScreen::create_separator(lv_obj_t* parent, const char* text) {

--- a/src/ui/screens/menu_screen.h
+++ b/src/ui/screens/menu_screen.h
@@ -53,6 +53,8 @@ private:
     lv_obj_t* brightness_screensaver_slider;
     lv_obj_t* brightness_normal_label;
     lv_obj_t* brightness_screensaver_label;
+    lv_obj_t* screensaver_startup_toggle;
+    lv_obj_t* screensaver_sleep_toggle;
     lv_obj_t* purge_button;
     lv_obj_t* reset_button;
     
@@ -139,6 +141,9 @@ public:
     lv_obj_t* get_grinder_purge_mode_radio_group() const { return grinder_purge_mode_radio_group; }
     lv_obj_t* get_grinder_purge_amount_slider() const { return grinder_purge_amount_slider; }
     lv_obj_t* get_grind_freshness_hours_slider() const { return grind_freshness_hours_slider; }
+    lv_obj_t* get_screensaver_startup_toggle() const { return screensaver_startup_toggle; }
+    lv_obj_t* get_screensaver_sleep_toggle() const { return screensaver_sleep_toggle; }
+    void update_screensaver_toggles();
 
 private:
     void create_menu_ui();

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -57,8 +57,22 @@ void UIManager::init(HardwareManager* hw_mgr, StateMachine* sm,
     
     // Register grind event callback
     grind_controller->set_ui_event_callback(GrindingUIController::dispatch_event);
-    
-    
+
+    // Show startup screensaver if enabled and image exists
+    if (screensaver_controller_ &&
+        screensaver_controller_->is_startup_enabled() &&
+        screensaver_controller_->has_image()) {
+        screensaver_controller_->show();
+        // Auto-hide after 3 seconds
+        lv_timer_create([](lv_timer_t* t) {
+            auto* sc = static_cast<ScreensaverController*>(lv_timer_get_user_data(t));
+            if (sc && sc->is_visible()) {
+                sc->hide();
+            }
+            lv_timer_delete(t);
+        }, 3000, screensaver_controller_.get());
+    }
+
     initialized = true;
 }
 
@@ -315,12 +329,18 @@ void UIManager::init_controllers() {
     confirm_controller_ = std::make_unique<ConfirmUIController>(this);
     ota_data_export_controller_ = std::make_unique<OtaDataExportController>(this);
     screen_timeout_controller_ = std::make_unique<ScreenTimeoutController>(this);
+    screensaver_controller_ = std::make_unique<ScreensaverController>();
     jog_adjust_controller_ = std::make_unique<JogAdjustController>(this);
     diagnostics_controller_ = std::make_unique<DiagnosticsController>();
 
     // Initialize diagnostics controller
     if (diagnostics_controller_) {
         diagnostics_controller_->init(hardware_manager);
+    }
+
+    // Wire screensaver controller into screen timeout controller
+    if (screen_timeout_controller_ && screensaver_controller_) {
+        screen_timeout_controller_->set_screensaver_controller(screensaver_controller_.get());
     }
 }
 

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -58,19 +58,21 @@ void UIManager::init(HardwareManager* hw_mgr, StateMachine* sm,
     // Register grind event callback
     grind_controller->set_ui_event_callback(GrindingUIController::dispatch_event);
 
-    // Show startup screensaver if enabled and image exists
+    // Show startup screensaver only on normal ready boot, never over boot warnings.
     if (screensaver_controller_ &&
+        state_machine &&
+        state_machine->is_state(UIState::READY) &&
         screensaver_controller_->is_startup_enabled() &&
         screensaver_controller_->has_image()) {
         screensaver_controller_->show();
-        // Auto-hide after 3 seconds
+        uint32_t startup_timeout_ms = screensaver_controller_->get_startup_timeout_ms();
         lv_timer_create([](lv_timer_t* t) {
             auto* sc = static_cast<ScreensaverController*>(lv_timer_get_user_data(t));
             if (sc && sc->is_visible()) {
                 sc->hide();
             }
             lv_timer_delete(t);
-        }, 3000, screensaver_controller_.get());
+        }, startup_timeout_ms, screensaver_controller_.get());
     }
 
     initialized = true;

--- a/src/ui/ui_manager.h
+++ b/src/ui/ui_manager.h
@@ -25,6 +25,7 @@
 #include "controllers/ota_data_export_controller.h"
 #include "controllers/ready_controller.h"
 #include "controllers/screen_timeout_controller.h"
+#include "controllers/screensaver_controller.h"
 #include "controllers/menu_controller.h"
 #include "controllers/status_indicator_controller.h"
 #include "../system/state_machine.h"
@@ -95,6 +96,7 @@ private:
     std::unique_ptr<ConfirmUIController> confirm_controller_;
     std::unique_ptr<OtaDataExportController> ota_data_export_controller_;
     std::unique_ptr<ScreenTimeoutController> screen_timeout_controller_;
+    std::unique_ptr<ScreensaverController> screensaver_controller_;
     std::unique_ptr<JogAdjustController> jog_adjust_controller_;
     std::unique_ptr<DiagnosticsController> diagnostics_controller_;
 

--- a/tools/web-flasher/README.md
+++ b/tools/web-flasher/README.md
@@ -16,6 +16,11 @@ A browser-based firmware flashing tool for the Smart Grind By Weight ESP32 coffe
 - Full firmware updates (no delta compression)
 - Progress tracking and status updates
 
+### 🖼️ Screensaver
+- Upload a custom 280 × 456 RGB565 screensaver image
+- Configure idle timeout and startup image duration over BLE
+- Brightness and image enable toggles remain on the grinder
+
 ## Browser Support
 
 - ✅ **Chrome** (Desktop & Android) - Full support
@@ -39,6 +44,13 @@ A browser-based firmware flashing tool for the Smart Grind By Weight ESP32 coffe
 4. Click "Connect to Device"
 5. Click "Flash Firmware" when connected
 
+### For Screensaver Settings
+1. Ensure grinder is powered and BLE enabled
+2. Go to the "Screensaver" tab
+3. Click "Connect & Load Settings" to read current timing values
+4. Set idle timeout (30-3600 seconds) and startup timeout (1-30 seconds)
+5. Click "Save Settings"
+
 ## Firmware Sources
 
 The firmware list is pulled straight from GitHub Releases—no files are stored in this repo. If you need the exact asset mapping, see [DOC.md](../../docs/DOC.md).
@@ -47,15 +59,20 @@ The firmware list is pulled straight from GitHub Releases—no files are stored 
 
 ### BLE Services Used
 - **OTA Service**: `12345678-1234-1234-1234-123456789abc`
-- **Data Transfer**: `87654321-4321-4321-4321-cba987654321`
-- **Control Commands**: `11111111-2222-3333-4444-555555555555`
-- **Status Updates**: `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`
+- **OTA Data**: `87654321-4321-4321-4321-cba987654321`
+- **OTA Control**: `11111111-2222-3333-4444-555555555555`
+- **OTA Status**: `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`
+- **Data Service**: `22334455-6677-8899-aabb-ccddeeffffaa`
+- **Data Control**: `33445566-7788-99aa-bbcc-ddeeffaabbcc`
+- **Data Transfer**: `44556677-8899-aabb-ccdd-eeffaabbccdd`
+- **Data Status**: `55667788-99aa-bbcc-ddee-ffaabbccddee`
 
 ### Protocol
 - Based on existing Python BLE implementation
 - 512-byte chunks for firmware transfer
 - Status notifications for progress tracking
 - Command structure: START → DATA_CHUNKS → END
+- Screensaver image upload and timing settings reuse the Data service
 
 ## Development
 

--- a/tools/web-flasher/flasher.js
+++ b/tools/web-flasher/flasher.js
@@ -19,6 +19,30 @@ const BLE_DEBUG_TX_CHAR_UUID = '6e400003-b5a3-f393-e0a9-e50e24dcca9e';
 const BLE_SYSINFO_SERVICE_UUID = '77889900-aabb-ccdd-eeff-112233445566';
 const BLE_SYSINFO_DIAGNOSTICS_CHAR_UUID = '22334455-ff00-1111-2222-334455667788';
 
+// Image upload uses the existing Data Service (no separate service needed)
+// Data Service UUIDs are defined above as BLE_DATA_*
+const BLE_DATA_CONTROL_CHAR_UUID = '33445566-7788-99aa-bbcc-ddeeffaabbcc';
+const BLE_DATA_TRANSFER_CHAR_UUID = '44556677-8899-aabb-ccdd-eeffaabbccdd';
+const BLE_DATA_STATUS_CHAR_UUID = '55667788-99aa-bbcc-ddee-ffaabbccddee';
+const BLE_DATA_SERVICE_UUID = '22334455-6677-8899-aabb-ccddeeffffaa';
+
+// Image upload commands (0x30+ range, sent via data control characteristic)
+const BLE_IMG_CMD_START = 0x30;
+const BLE_IMG_CMD_END = 0x32;
+const BLE_IMG_CMD_ABORT = 0x33;
+const BLE_IMG_CMD_DELETE = 0x34;
+
+const BLE_IMG_STATUS_IDLE = 0x30;
+const BLE_IMG_STATUS_READY = 0x31;
+const BLE_IMG_STATUS_RECEIVING = 0x32;
+const BLE_IMG_STATUS_SUCCESS = 0x33;
+const BLE_IMG_STATUS_ERROR = 0x34;
+const BLE_IMG_STATUS_HAS_IMAGE = 0x35;
+
+const IMAGE_WIDTH = 280;
+const IMAGE_HEIGHT = 456;
+const IMAGE_EXPECTED_SIZE = IMAGE_WIDTH * IMAGE_HEIGHT * 2; // RGB565
+
 // Commands and status codes (from your Python implementation)
 const BLE_OTA_CMD_START = 0x01;
 const BLE_OTA_CMD_END = 0x03;
@@ -724,6 +748,227 @@ function downloadDiagnosticReport() {
         }, 3000);
     } catch (error) {
         statusDiv.innerHTML = '<div class="status error">Failed to download report.</div>';
+    }
+}
+
+// =============================================================================
+// SCREENSAVER IMAGE UPLOAD
+// =============================================================================
+
+let screensaverRgb565Data = null; // Converted image data ready for upload
+
+function updateScreensaverStatus(message, type = 'info') {
+    const el = document.getElementById('screensaverStatus');
+    el.textContent = message;
+    el.className = `status ${type}`;
+    el.style.display = 'block';
+    console.log(`[SCREENSAVER ${type.toUpperCase()}] ${message}`);
+}
+
+function updateScreensaverProgress(percent) {
+    const container = document.getElementById('screensaverProgressContainer');
+    const bar = document.getElementById('screensaverProgressBar');
+    if (percent > 0) {
+        container.style.display = 'block';
+        bar.style.width = percent + '%';
+    } else {
+        container.style.display = 'none';
+    }
+}
+
+function handleScreensaverFileSelect(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    screensaverRgb565Data = null;
+    document.getElementById('uploadScreensaverBtn').disabled = true;
+
+    const validationEl = document.getElementById('screensaverValidation');
+    validationEl.style.display = 'block';
+    validationEl.textContent = 'Validating image...';
+    validationEl.className = 'status info';
+
+    const img = new Image();
+    img.onload = () => {
+        URL.revokeObjectURL(img.src);
+
+        if (img.width !== IMAGE_WIDTH || img.height !== IMAGE_HEIGHT) {
+            validationEl.textContent = `Invalid dimensions: ${img.width} x ${img.height}. Required: ${IMAGE_WIDTH} x ${IMAGE_HEIGHT} pixels.`;
+            validationEl.className = 'status error';
+            document.getElementById('screensaverPreviewContainer').style.display = 'none';
+            return;
+        }
+
+        // Draw to canvas for preview and conversion
+        const canvas = document.getElementById('screensaverPreview');
+        canvas.width = IMAGE_WIDTH;
+        canvas.height = IMAGE_HEIGHT;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0);
+        document.getElementById('screensaverPreviewContainer').style.display = 'block';
+
+        // Convert to RGB565 (byte-swapped for LV_COLOR_16_SWAP = 1)
+        const imageData = ctx.getImageData(0, 0, IMAGE_WIDTH, IMAGE_HEIGHT);
+        screensaverRgb565Data = rgbaToRgb565(imageData.data);
+
+        validationEl.textContent = `Image valid: ${IMAGE_WIDTH} x ${IMAGE_HEIGHT} pixels (${(screensaverRgb565Data.length / 1024).toFixed(0)} KB)`;
+        validationEl.className = 'status success';
+        document.getElementById('uploadScreensaverBtn').disabled = false;
+    };
+
+    img.onerror = () => {
+        URL.revokeObjectURL(img.src);
+        validationEl.textContent = 'Failed to load image file.';
+        validationEl.className = 'status error';
+    };
+
+    img.src = URL.createObjectURL(file);
+}
+
+/**
+ * Convert RGBA pixel data to native (little-endian) RGB565.
+ * LVGL uses LV_COLOR_FORMAT_RGB565 internally and the display driver
+ * handles byte swapping (LV_COLOR_16_SWAP) during flush.
+ */
+function rgbaToRgb565(rgba) {
+    const rgb565 = new Uint8Array(IMAGE_WIDTH * IMAGE_HEIGHT * 2);
+    for (let i = 0, j = 0; i < rgba.length; i += 4, j += 2) {
+        const r = rgba[i];
+        const g = rgba[i + 1];
+        const b = rgba[i + 2];
+        const pixel = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
+        // Little-endian: low byte first
+        rgb565[j] = pixel & 0xFF;
+        rgb565[j + 1] = (pixel >> 8) & 0xFF;
+    }
+    return rgb565;
+}
+
+async function uploadScreensaver() {
+    if (!screensaverRgb565Data) {
+        updateScreensaverStatus('No valid image to upload.', 'error');
+        return;
+    }
+
+    const uploadBtn = document.getElementById('uploadScreensaverBtn');
+    uploadBtn.disabled = true;
+
+    try {
+        updateScreensaverStatus('Connecting to device...', 'info');
+
+        // Connect via BLE (image upload uses the existing data service)
+        const bleDevice = await navigator.bluetooth.requestDevice({
+            filters: [{ name: DEVICE_NAME }],
+            optionalServices: [BLE_DATA_SERVICE_UUID]
+        });
+
+        const bleServer = await bleDevice.gatt.connect();
+        updateScreensaverStatus('Getting data service...', 'info');
+
+        const dataService = await bleServer.getPrimaryService(BLE_DATA_SERVICE_UUID);
+        const dataChar = await dataService.getCharacteristic(BLE_DATA_TRANSFER_CHAR_UUID);
+        const controlChar = await dataService.getCharacteristic(BLE_DATA_CONTROL_CHAR_UUID);
+        const imgStatusChar = await dataService.getCharacteristic(BLE_DATA_STATUS_CHAR_UUID);
+
+        // Set up status notifications
+        let lastStatus = BLE_IMG_STATUS_IDLE;
+        await imgStatusChar.startNotifications();
+        imgStatusChar.addEventListener('characteristicvaluechanged', (event) => {
+            const val = new Uint8Array(event.target.value.buffer);
+            if (val.length > 0) lastStatus = val[0];
+        });
+
+        // Send START command: [0x10][size:4 LE]
+        updateScreensaverStatus('Starting upload...', 'info');
+        const startCmd = new Uint8Array(5);
+        startCmd[0] = BLE_IMG_CMD_START;
+        startCmd[1] = screensaverRgb565Data.length & 0xFF;
+        startCmd[2] = (screensaverRgb565Data.length >> 8) & 0xFF;
+        startCmd[3] = (screensaverRgb565Data.length >> 16) & 0xFF;
+        startCmd[4] = (screensaverRgb565Data.length >> 24) & 0xFF;
+        await controlChar.writeValue(startCmd);
+
+        await sleep(200); // Wait for device to prepare
+
+        if (lastStatus === BLE_IMG_STATUS_ERROR) {
+            throw new Error('Device rejected the upload (check image size or OTA status)');
+        }
+
+        // Send data in chunks
+        const totalChunks = Math.ceil(screensaverRgb565Data.length / CHUNK_SIZE);
+        updateScreensaverStatus(`Uploading image (${totalChunks} chunks)...`, 'info');
+        updateScreensaverProgress(0);
+
+        for (let offset = 0; offset < screensaverRgb565Data.length; offset += CHUNK_SIZE) {
+            const end = Math.min(offset + CHUNK_SIZE, screensaverRgb565Data.length);
+            const chunk = screensaverRgb565Data.slice(offset, end);
+            await dataChar.writeValue(chunk);
+
+            const percent = Math.round((end / screensaverRgb565Data.length) * 100);
+            updateScreensaverProgress(percent);
+        }
+
+        // Send END command
+        updateScreensaverStatus('Finalizing...', 'info');
+        const endCmd = new Uint8Array([BLE_IMG_CMD_END]);
+        await controlChar.writeValue(endCmd);
+
+        await sleep(500); // Wait for device to finalize
+
+        if (lastStatus === BLE_IMG_STATUS_ERROR) {
+            throw new Error('Device reported error during finalization');
+        }
+
+        updateScreensaverStatus('Screensaver image uploaded successfully!', 'success');
+        updateScreensaverProgress(100);
+
+        // Disconnect
+        await sleep(500);
+        if (bleDevice.gatt.connected) {
+            bleDevice.gatt.disconnect();
+        }
+
+    } catch (error) {
+        updateScreensaverStatus(`Upload failed: ${error.message}`, 'error');
+        console.error('Screensaver upload error:', error);
+    } finally {
+        uploadBtn.disabled = !screensaverRgb565Data;
+        setTimeout(() => updateScreensaverProgress(0), 3000);
+    }
+}
+
+async function deleteScreensaver() {
+    const deleteBtn = document.getElementById('deleteScreensaverBtn');
+    deleteBtn.disabled = true;
+
+    try {
+        updateScreensaverStatus('Connecting to device...', 'info');
+
+        const bleDevice = await navigator.bluetooth.requestDevice({
+            filters: [{ name: DEVICE_NAME }],
+            optionalServices: [BLE_DATA_SERVICE_UUID]
+        });
+
+        const bleServer = await bleDevice.gatt.connect();
+        const dataService = await bleServer.getPrimaryService(BLE_DATA_SERVICE_UUID);
+        const controlChar = await dataService.getCharacteristic(BLE_DATA_CONTROL_CHAR_UUID);
+
+        // Send DELETE command
+        const deleteCmd = new Uint8Array([BLE_IMG_CMD_DELETE]);
+        await controlChar.writeValue(deleteCmd);
+
+        await sleep(500);
+        updateScreensaverStatus('Screensaver image deleted from device.', 'success');
+
+        if (bleDevice.gatt.connected) {
+            bleDevice.gatt.disconnect();
+        }
+
+    } catch (error) {
+        updateScreensaverStatus(`Delete failed: ${error.message}`, 'error');
+        console.error('Screensaver delete error:', error);
+    } finally {
+        deleteBtn.disabled = false;
     }
 }
 

--- a/tools/web-flasher/flasher.js
+++ b/tools/web-flasher/flasher.js
@@ -39,9 +39,25 @@ const BLE_IMG_STATUS_SUCCESS = 0x33;
 const BLE_IMG_STATUS_ERROR = 0x34;
 const BLE_IMG_STATUS_HAS_IMAGE = 0x35;
 
+// Screensaver settings commands/statuses (0x40+ range on Data Service)
+const BLE_SETTINGS_CMD_GET_SCREENSAVER = 0x40;
+const BLE_SETTINGS_CMD_SET_SCREENSAVER = 0x41;
+const BLE_SETTINGS_STATUS_VALUE = 0x42;
+const BLE_SETTINGS_STATUS_ERROR = 0x44;
+
+const BLE_SETTINGS_ERROR_BUSY = 0x01;
+const BLE_SETTINGS_ERROR_INVALID_LENGTH = 0x02;
+const BLE_SETTINGS_ERROR_INVALID_RANGE = 0x03;
+const BLE_SETTINGS_ERROR_STORAGE = 0x04;
+
 const IMAGE_WIDTH = 280;
 const IMAGE_HEIGHT = 456;
 const IMAGE_EXPECTED_SIZE = IMAGE_WIDTH * IMAGE_HEIGHT * 2; // RGB565
+
+const SCREENSAVER_IDLE_TIMEOUT_MIN_S = 30;
+const SCREENSAVER_IDLE_TIMEOUT_MAX_S = 3600;
+const SCREENSAVER_STARTUP_TIMEOUT_MIN_S = 1;
+const SCREENSAVER_STARTUP_TIMEOUT_MAX_S = 30;
 
 // Commands and status codes (from your Python implementation)
 const BLE_OTA_CMD_START = 0x01;
@@ -776,6 +792,194 @@ function updateScreensaverProgress(percent) {
     }
 }
 
+async function connectScreensaverDataService() {
+    const bleDevice = await navigator.bluetooth.requestDevice({
+        filters: [{ name: DEVICE_NAME }],
+        optionalServices: [BLE_DATA_SERVICE_UUID]
+    });
+
+    const bleServer = await bleDevice.gatt.connect();
+    const dataService = await bleServer.getPrimaryService(BLE_DATA_SERVICE_UUID);
+
+    return {
+        bleDevice,
+        dataChar: await dataService.getCharacteristic(BLE_DATA_TRANSFER_CHAR_UUID),
+        controlChar: await dataService.getCharacteristic(BLE_DATA_CONTROL_CHAR_UUID),
+        statusChar: await dataService.getCharacteristic(BLE_DATA_STATUS_CHAR_UUID)
+    };
+}
+
+function disconnectBleDevice(bleDevice) {
+    if (bleDevice?.gatt?.connected) {
+        bleDevice.gatt.disconnect();
+    }
+}
+
+function screensaverSettingsErrorMessage(code) {
+    switch (code) {
+        case BLE_SETTINGS_ERROR_BUSY:
+            return 'Device is busy with OTA, data export, or image upload.';
+        case BLE_SETTINGS_ERROR_INVALID_LENGTH:
+            return 'Device rejected the settings payload.';
+        case BLE_SETTINGS_ERROR_INVALID_RANGE:
+            return 'One or more values are outside the supported range.';
+        case BLE_SETTINGS_ERROR_STORAGE:
+            return 'Device could not save settings.';
+        default:
+            return `Device rejected settings (error ${code}).`;
+    }
+}
+
+function waitForScreensaverSettings(statusChar, timeoutMs = 5000) {
+    return new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+            cleanup();
+            reject(new Error('Timed out waiting for screensaver settings'));
+        }, timeoutMs);
+
+        const handler = (event) => {
+            const val = new Uint8Array(event.target.value.buffer);
+            if (val.length === 0) return;
+
+            if (val[0] === BLE_SETTINGS_STATUS_VALUE && val.length >= 4) {
+                cleanup();
+                resolve({
+                    idleTimeoutS: val[1] | (val[2] << 8),
+                    startupTimeoutS: val[3]
+                });
+            } else if (val[0] === BLE_SETTINGS_STATUS_ERROR) {
+                cleanup();
+                const code = val.length >= 2 ? val[1] : 0;
+                reject(new Error(screensaverSettingsErrorMessage(code)));
+            }
+        };
+
+        function cleanup() {
+            clearTimeout(timeoutId);
+            statusChar.removeEventListener('characteristicvaluechanged', handler);
+        }
+
+        statusChar.addEventListener('characteristicvaluechanged', handler);
+    });
+}
+
+function applyScreensaverSettings(settings) {
+    document.getElementById('screensaverIdleTimeout').value = settings.idleTimeoutS;
+    document.getElementById('screensaverStartupTimeout').value = settings.startupTimeoutS;
+}
+
+function readSecondsInput(id, min, max, label) {
+    const input = document.getElementById(id);
+    const value = Number.parseInt(input.value, 10);
+
+    if (!Number.isInteger(value) || value < min || value > max) {
+        throw new Error(`${label} must be between ${min} and ${max} seconds.`);
+    }
+
+    return value;
+}
+
+async function loadScreensaverSettings() {
+    const loadBtn = document.getElementById('loadScreensaverSettingsBtn');
+    const saveBtn = document.getElementById('saveScreensaverSettingsBtn');
+    let bleDevice = null;
+    let statusChar = null;
+
+    try {
+        loadBtn.disabled = true;
+        saveBtn.disabled = true;
+        updateScreensaverStatus('Connecting to device...', 'info');
+
+        const connection = await connectScreensaverDataService();
+        bleDevice = connection.bleDevice;
+        statusChar = connection.statusChar;
+
+        await statusChar.startNotifications();
+        const settingsPromise = waitForScreensaverSettings(statusChar);
+
+        updateScreensaverStatus('Loading screensaver settings...', 'info');
+        await connection.controlChar.writeValue(new Uint8Array([BLE_SETTINGS_CMD_GET_SCREENSAVER]));
+
+        const settings = await settingsPromise;
+        applyScreensaverSettings(settings);
+        updateScreensaverStatus('Screensaver settings loaded.', 'success');
+    } catch (error) {
+        updateScreensaverStatus(`Load failed: ${error.message}`, 'error');
+        console.error('Screensaver settings load error:', error);
+    } finally {
+        if (statusChar) {
+            try {
+                await statusChar.stopNotifications();
+            } catch (e) {
+                // Ignore cleanup errors.
+            }
+        }
+        disconnectBleDevice(bleDevice);
+        loadBtn.disabled = false;
+        saveBtn.disabled = false;
+    }
+}
+
+async function saveScreensaverSettings() {
+    const loadBtn = document.getElementById('loadScreensaverSettingsBtn');
+    const saveBtn = document.getElementById('saveScreensaverSettingsBtn');
+    let bleDevice = null;
+    let statusChar = null;
+
+    try {
+        const idleTimeoutS = readSecondsInput(
+            'screensaverIdleTimeout',
+            SCREENSAVER_IDLE_TIMEOUT_MIN_S,
+            SCREENSAVER_IDLE_TIMEOUT_MAX_S,
+            'Idle timeout'
+        );
+        const startupTimeoutS = readSecondsInput(
+            'screensaverStartupTimeout',
+            SCREENSAVER_STARTUP_TIMEOUT_MIN_S,
+            SCREENSAVER_STARTUP_TIMEOUT_MAX_S,
+            'Startup timeout'
+        );
+
+        loadBtn.disabled = true;
+        saveBtn.disabled = true;
+        updateScreensaverStatus('Connecting to device...', 'info');
+
+        const connection = await connectScreensaverDataService();
+        bleDevice = connection.bleDevice;
+        statusChar = connection.statusChar;
+
+        await statusChar.startNotifications();
+        const settingsPromise = waitForScreensaverSettings(statusChar);
+
+        const payload = new Uint8Array(4);
+        payload[0] = BLE_SETTINGS_CMD_SET_SCREENSAVER;
+        payload[1] = idleTimeoutS & 0xFF;
+        payload[2] = (idleTimeoutS >> 8) & 0xFF;
+        payload[3] = startupTimeoutS;
+
+        updateScreensaverStatus('Saving screensaver settings...', 'info');
+        await connection.controlChar.writeValue(payload);
+
+        const settings = await settingsPromise;
+        applyScreensaverSettings(settings);
+        updateScreensaverStatus('Screensaver settings saved.', 'success');
+    } catch (error) {
+        updateScreensaverStatus(`Save failed: ${error.message}`, 'error');
+        console.error('Screensaver settings save error:', error);
+    } finally {
+        if (statusChar) {
+            try {
+                await statusChar.stopNotifications();
+            } catch (e) {
+                // Ignore cleanup errors.
+            }
+        }
+        disconnectBleDevice(bleDevice);
+        loadBtn.disabled = false;
+        saveBtn.disabled = false;
+    }
+}
+
 function handleScreensaverFileSelect(event) {
     const file = event.target.files[0];
     if (!file) return;
@@ -852,33 +1056,31 @@ async function uploadScreensaver() {
 
     const uploadBtn = document.getElementById('uploadScreensaverBtn');
     uploadBtn.disabled = true;
+    let bleDevice = null;
+    let controlChar = null;
+    let statusChar = null;
+    let statusHandler = null;
+    let uploadActive = false;
 
     try {
         updateScreensaverStatus('Connecting to device...', 'info');
 
-        // Connect via BLE (image upload uses the existing data service)
-        const bleDevice = await navigator.bluetooth.requestDevice({
-            filters: [{ name: DEVICE_NAME }],
-            optionalServices: [BLE_DATA_SERVICE_UUID]
-        });
-
-        const bleServer = await bleDevice.gatt.connect();
+        const connection = await connectScreensaverDataService();
+        bleDevice = connection.bleDevice;
+        controlChar = connection.controlChar;
+        statusChar = connection.statusChar;
         updateScreensaverStatus('Getting data service...', 'info');
-
-        const dataService = await bleServer.getPrimaryService(BLE_DATA_SERVICE_UUID);
-        const dataChar = await dataService.getCharacteristic(BLE_DATA_TRANSFER_CHAR_UUID);
-        const controlChar = await dataService.getCharacteristic(BLE_DATA_CONTROL_CHAR_UUID);
-        const imgStatusChar = await dataService.getCharacteristic(BLE_DATA_STATUS_CHAR_UUID);
 
         // Set up status notifications
         let lastStatus = BLE_IMG_STATUS_IDLE;
-        await imgStatusChar.startNotifications();
-        imgStatusChar.addEventListener('characteristicvaluechanged', (event) => {
+        await statusChar.startNotifications();
+        statusHandler = (event) => {
             const val = new Uint8Array(event.target.value.buffer);
             if (val.length > 0) lastStatus = val[0];
-        });
+        };
+        statusChar.addEventListener('characteristicvaluechanged', statusHandler);
 
-        // Send START command: [0x10][size:4 LE]
+        // Send START command: [0x30][size:4 LE]
         updateScreensaverStatus('Starting upload...', 'info');
         const startCmd = new Uint8Array(5);
         startCmd[0] = BLE_IMG_CMD_START;
@@ -887,6 +1089,7 @@ async function uploadScreensaver() {
         startCmd[3] = (screensaverRgb565Data.length >> 16) & 0xFF;
         startCmd[4] = (screensaverRgb565Data.length >> 24) & 0xFF;
         await controlChar.writeValue(startCmd);
+        uploadActive = true;
 
         await sleep(200); // Wait for device to prepare
 
@@ -902,7 +1105,7 @@ async function uploadScreensaver() {
         for (let offset = 0; offset < screensaverRgb565Data.length; offset += CHUNK_SIZE) {
             const end = Math.min(offset + CHUNK_SIZE, screensaverRgb565Data.length);
             const chunk = screensaverRgb565Data.slice(offset, end);
-            await dataChar.writeValue(chunk);
+            await connection.dataChar.writeValue(chunk);
 
             const percent = Math.round((end / screensaverRgb565Data.length) * 100);
             updateScreensaverProgress(percent);
@@ -918,20 +1121,34 @@ async function uploadScreensaver() {
         if (lastStatus === BLE_IMG_STATUS_ERROR) {
             throw new Error('Device reported error during finalization');
         }
+        uploadActive = false;
 
         updateScreensaverStatus('Screensaver image uploaded successfully!', 'success');
         updateScreensaverProgress(100);
-
-        // Disconnect
-        await sleep(500);
-        if (bleDevice.gatt.connected) {
-            bleDevice.gatt.disconnect();
-        }
 
     } catch (error) {
         updateScreensaverStatus(`Upload failed: ${error.message}`, 'error');
         console.error('Screensaver upload error:', error);
     } finally {
+        if (uploadActive && controlChar && bleDevice?.gatt?.connected) {
+            try {
+                await controlChar.writeValue(new Uint8Array([BLE_IMG_CMD_ABORT]));
+            } catch (abortError) {
+                console.error('Could not abort screensaver upload:', abortError);
+            }
+        }
+
+        if (statusChar && statusHandler) {
+            statusChar.removeEventListener('characteristicvaluechanged', statusHandler);
+            try {
+                await statusChar.stopNotifications();
+            } catch (e) {
+                // Ignore cleanup errors.
+            }
+        }
+
+        await sleep(200);
+        disconnectBleDevice(bleDevice);
         uploadBtn.disabled = !screensaverRgb565Data;
         setTimeout(() => updateScreensaverProgress(0), 3000);
     }
@@ -940,34 +1157,26 @@ async function uploadScreensaver() {
 async function deleteScreensaver() {
     const deleteBtn = document.getElementById('deleteScreensaverBtn');
     deleteBtn.disabled = true;
+    let bleDevice = null;
 
     try {
         updateScreensaverStatus('Connecting to device...', 'info');
 
-        const bleDevice = await navigator.bluetooth.requestDevice({
-            filters: [{ name: DEVICE_NAME }],
-            optionalServices: [BLE_DATA_SERVICE_UUID]
-        });
-
-        const bleServer = await bleDevice.gatt.connect();
-        const dataService = await bleServer.getPrimaryService(BLE_DATA_SERVICE_UUID);
-        const controlChar = await dataService.getCharacteristic(BLE_DATA_CONTROL_CHAR_UUID);
+        const connection = await connectScreensaverDataService();
+        bleDevice = connection.bleDevice;
 
         // Send DELETE command
         const deleteCmd = new Uint8Array([BLE_IMG_CMD_DELETE]);
-        await controlChar.writeValue(deleteCmd);
+        await connection.controlChar.writeValue(deleteCmd);
 
         await sleep(500);
         updateScreensaverStatus('Screensaver image deleted from device.', 'success');
-
-        if (bleDevice.gatt.connected) {
-            bleDevice.gatt.disconnect();
-        }
 
     } catch (error) {
         updateScreensaverStatus(`Delete failed: ${error.message}`, 'error');
         console.error('Screensaver delete error:', error);
     } finally {
+        disconnectBleDevice(bleDevice);
         deleteBtn.disabled = false;
     }
 }

--- a/tools/web-flasher/index.html
+++ b/tools/web-flasher/index.html
@@ -232,6 +232,7 @@
         <div class="tabs">
             <button class="tab active" onclick="showTab('ota')">OTA Update (BLE)</button>
             <button class="tab" onclick="showTab('initial')">Initial Setup (USB)</button>
+            <button class="tab" onclick="showTab('screensaver')">Screensaver</button>
             <button class="tab" onclick="showTab('diagnostics')">Diagnostics</button>
         </div>
         
@@ -304,6 +305,37 @@
             
             <div class="progress" id="progressContainer" style="display: none;">
                 <div class="progress-bar" id="progressBar"></div>
+            </div>
+        </div>
+
+        <!-- Screensaver Tab -->
+        <div id="screensaverTab" class="tab-content">
+            <div class="section">
+                <h3>🖼️ Custom Screensaver Image</h3>
+                <p>Upload a custom image to display on startup or when the grinder enters power-saving mode. The image must be exactly <strong>280 x 456 pixels</strong>.</p>
+            </div>
+
+            <div class="form-group">
+                <label for="screensaverFile">Select Image File</label>
+                <input type="file" id="screensaverFile" accept=".png,.jpg,.jpeg,.bmp,.webp" onchange="handleScreensaverFileSelect(event)">
+            </div>
+
+            <div id="screensaverPreviewContainer" style="display: none; text-align: center; margin-bottom: 20px;">
+                <canvas id="screensaverPreview" style="border: 2px solid #e2e8f0; border-radius: 8px; max-width: 100%; height: auto;"></canvas>
+            </div>
+
+            <div id="screensaverValidation" class="status" style="display: none;"></div>
+
+            <button class="btn" id="uploadScreensaverBtn" onclick="uploadScreensaver()" disabled>Upload to Device</button>
+
+            <div class="progress" id="screensaverProgressContainer" style="display: none;">
+                <div class="progress-bar" id="screensaverProgressBar"></div>
+            </div>
+
+            <div id="screensaverStatus" class="status info" style="display: none;"></div>
+
+            <div style="margin-top: 20px;">
+                <button class="btn" id="deleteScreensaverBtn" onclick="deleteScreensaver()" style="background: linear-gradient(135deg, #e53e3e 0%, #c53030 100%);">Delete Image from Device</button>
             </div>
         </div>
 

--- a/tools/web-flasher/index.html
+++ b/tools/web-flasher/index.html
@@ -92,7 +92,7 @@
             color: #4a5568;
         }
         
-        input[type="text"], input[type="file"], select {
+        input[type="text"], input[type="number"], input[type="file"], select {
             width: 100%;
             padding: 12px;
             border: 2px solid #e2e8f0;
@@ -210,6 +210,22 @@
         #browserWarning {
             display: none;
         }
+
+        .button-row {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+        }
+
+        .button-row .btn {
+            flex: 1;
+        }
+
+        @media (max-width: 600px) {
+            .button-row {
+                flex-direction: column;
+            }
+        }
     </style>
 </head>
 <body>
@@ -313,6 +329,26 @@
             <div class="section">
                 <h3>🖼️ Custom Screensaver Image</h3>
                 <p>Upload a custom image to display on startup or when the grinder enters power-saving mode. The image must be exactly <strong>280 x 456 pixels</strong>.</p>
+            </div>
+
+            <div class="section">
+                <h3>⏱️ Screensaver Timing</h3>
+                <p>Set the idle timeout and startup image duration. Screensaver brightness remains configurable on the grinder.</p>
+            </div>
+
+            <div class="form-group">
+                <label for="screensaverIdleTimeout">Idle Timeout (seconds)</label>
+                <input type="number" id="screensaverIdleTimeout" min="30" max="3600" step="1" value="300">
+            </div>
+
+            <div class="form-group">
+                <label for="screensaverStartupTimeout">Startup Timeout (seconds)</label>
+                <input type="number" id="screensaverStartupTimeout" min="1" max="30" step="1" value="3">
+            </div>
+
+            <div class="button-row">
+                <button class="btn" id="loadScreensaverSettingsBtn" onclick="loadScreensaverSettings()">Connect & Load Settings</button>
+                <button class="btn" id="saveScreensaverSettingsBtn" onclick="saveScreensaverSettings()">Save Settings</button>
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
## Summary
- Users can upload a custom 280x456 pixel screensaver image via the web flasher's new **Screensaver** tab over BLE
- Image is stored as raw RGB565 on LittleFS (~250KB) and can be shown on **startup** (auto-hides after 3 seconds) and/or when the display enters **power-saving/dim mode**
- Two independent toggles in **Menu > Display > Custom Image** control startup and sleep behavior; toggles are disabled when no image is uploaded
- Image upload reuses the existing BLE data service (0x30+ command range) to avoid additional BLE service heap allocation
- BLE service handle counts are now explicitly specified to reduce heap usage from the default 15-per-service allocation

## Test plan
- [ ] Upload a 280x456 image via web flasher Screensaver tab — verify success
- [ ] Try uploading a wrong-size image — verify rejection in browser
- [ ] Enable Startup toggle, reboot — verify image shows for 3s then auto-transitions
- [ ] Enable Sleep toggle, wait for dim timeout — verify image appears at dimmed brightness
- [ ] Touch screen during sleep screensaver — verify wake + normal screen restored
- [ ] Delete image via web flasher — verify toggles become disabled
- [ ] Verify OTA updates, data export, and normal grinding still work correctly