### PR TITLE
Allow time mode to run without weight sensor

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -87,6 +87,7 @@ The platform dependency is automatically handled by PlatformIO via the `platform
 **Build production firmware:**
 ```bash
 python3 tools/grinder.py build
+# Equivalent: platformio run -e waveshare-esp32s3-touch-amoled-164
 ```
 
 **Build debug firmware:**

--- a/src/controllers/grind_controller.cpp
+++ b/src/controllers/grind_controller.cpp
@@ -109,28 +109,29 @@ void GrindController::init(WeightSensor* lc, Grinder* gr, Preferences* prefs) {
 }
 
 void GrindController::start_grind(float target, uint32_t time_ms, GrindMode grind_mode) {
-    LOG_BLE("[%lums CONTROLLER] start_grind() called with target=%.1fg, time=%lums, mode=%s\n",
-            millis(), target, (unsigned long)time_ms, grind_mode == GrindMode::TIME ? "TIME" : "WEIGHT");
-    if (!weight_sensor || !grinder) return;
-    if (weight_sensor->has_hardware_fault()) {
-        LOG_BLE("ERROR: Cannot start grind - load cell hardware fault detected (%d)\n",
-                static_cast<int>(weight_sensor->get_hardware_fault()));
-        return;
-    }
-    
     target_weight = target;
     target_time_ms = time_ms;
     mode = grind_mode;
-
-    // Read grinder purge settings from preferences (always run for weight mode)
-    grinder_purge_mode_for_session = static_cast<GrinderPurgeMode>(GRIND_PURGE_MODE_DEFAULT);
-    grinder_purge_amount_g_for_session = GRIND_PURGE_AMOUNT_DEFAULT_G;
-    if (preferences) {
-        int purge_mode_int = preferences->getInt(PREF_KEY_GRINDER_MODE, GRIND_PURGE_MODE_DEFAULT);
-        grinder_purge_mode_for_session = static_cast<GrinderPurgeMode>(purge_mode_int);
-        float configured_amount = preferences->getFloat(PREF_KEY_GRINDER_AMOUNT_G, GRIND_PURGE_AMOUNT_DEFAULT_G);
-        configured_amount = std::clamp(configured_amount, GRIND_PURGE_AMOUNT_MIN_G, GRIND_PURGE_AMOUNT_MAX_G);
-        grinder_purge_amount_g_for_session = configured_amount;
+    LOG_BLE("[%lums CONTROLLER] start_grind() called with target=%.1fg, time=%lums, mode=%s\n",
+            millis(), target, (unsigned long)time_ms, grind_mode == GrindMode::TIME ? "TIME" : "WEIGHT");
+    if (!grinder) return;
+    if (mode == GrindMode::WEIGHT) {
+        if (!weight_sensor) return;
+        if (weight_sensor->has_hardware_fault()) {
+            LOG_BLE("ERROR: Cannot start grind - load cell hardware fault detected (%d)\n",
+                    static_cast<int>(weight_sensor->get_hardware_fault()));
+            return;
+        }
+        // Read grinder purge settings from preferences (weight mode only)
+        grinder_purge_mode_for_session = static_cast<GrinderPurgeMode>(GRIND_PURGE_MODE_DEFAULT);
+        grinder_purge_amount_g_for_session = GRIND_PURGE_AMOUNT_DEFAULT_G;
+        if (preferences) {
+            int purge_mode_int = preferences->getInt(PREF_KEY_GRINDER_MODE, GRIND_PURGE_MODE_DEFAULT);
+            grinder_purge_mode_for_session = static_cast<GrinderPurgeMode>(purge_mode_int);
+            float configured_amount = preferences->getFloat(PREF_KEY_GRINDER_AMOUNT_G, GRIND_PURGE_AMOUNT_DEFAULT_G);
+            configured_amount = std::clamp(configured_amount, GRIND_PURGE_AMOUNT_MIN_G, GRIND_PURGE_AMOUNT_MAX_G);
+            grinder_purge_amount_g_for_session = configured_amount;
+        }
     }
 
     start_time = millis();
@@ -550,7 +551,8 @@ void GrindController::update() {
 
     // Check for negative weight failsafe after TARE_CONFIRM phase during active grinding
     // Only check after motor has settled to avoid false positives from startup transients
-    if (phase != GrindPhase::COMPLETED && phase != GrindPhase::TIMEOUT &&
+    if (mode == GrindMode::WEIGHT &&
+        phase != GrindPhase::COMPLETED && phase != GrindPhase::TIMEOUT &&
         phase != GrindPhase::IDLE && phase != GrindPhase::INITIALIZING &&
         phase != GrindPhase::SETUP && phase != GrindPhase::TARING &&
         phase != GrindPhase::TARE_CONFIRM &&

--- a/src/hardware/WeightSensor.h
+++ b/src/hardware/WeightSensor.h
@@ -123,7 +123,7 @@ public:
     bool getTareStatus();                 // Exact HX711_ADC method
     
     // Legacy wrapper methods for compatibility
-    bool start_nonblocking_tare() { tareNoDelay(); return true; }
+    bool start_nonblocking_tare() { if (!has_hardware_fault()) { tareNoDelay(); } return true; }
     bool is_tare_in_progress() const { return doTare; }
     
     // Calibration

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -13,6 +13,7 @@ plotly>=5.15.0
 
 # Build system (use PlatformIO from the venv, not global `pio`)
 platformio>=6.0.0
+pyyaml>=6.0.0
 
 detools>=0.53.0
 


### PR DESCRIPTION
- start_grind() now guards weight sensor checks behind mode == WEIGHT, so time mode can start even when no HX711 is connected
- start_nonblocking_tare() skips the tare when a hardware fault is active, preventing TARE_CONFIRM from hanging indefinitely
- Negative weight failsafe is restricted to WEIGHT mode so the timer remains the sole authority over motor control in time mode
- Add pyyaml to requirements.txt (required by PlatformIO ESP32 builder)
- Document implicit -e env in DEVELOPMENT.md build section

Closes #84