### PR TITLE
Feature/time mode without weight sensor

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -87,6 +87,7 @@ The platform dependency is automatically handled by PlatformIO via the `platform
 **Build production firmware:**
 ```bash
 python3 tools/grinder.py build
+# Equivalent: platformio run -e waveshare-esp32s3-touch-amoled-164
 ```
 
 **Build debug firmware:**

--- a/src/controllers/grind_controller.cpp
+++ b/src/controllers/grind_controller.cpp
@@ -109,28 +109,29 @@ void GrindController::init(WeightSensor* lc, Grinder* gr, Preferences* prefs) {
 }
 
 void GrindController::start_grind(float target, uint32_t time_ms, GrindMode grind_mode) {
-    LOG_BLE("[%lums CONTROLLER] start_grind() called with target=%.1fg, time=%lums, mode=%s\n",
-            millis(), target, (unsigned long)time_ms, grind_mode == GrindMode::TIME ? "TIME" : "WEIGHT");
-    if (!weight_sensor || !grinder) return;
-    if (weight_sensor->has_hardware_fault()) {
-        LOG_BLE("ERROR: Cannot start grind - load cell hardware fault detected (%d)\n",
-                static_cast<int>(weight_sensor->get_hardware_fault()));
-        return;
-    }
-    
     target_weight = target;
     target_time_ms = time_ms;
     mode = grind_mode;
-
-    // Read grinder purge settings from preferences (always run for weight mode)
-    grinder_purge_mode_for_session = static_cast<GrinderPurgeMode>(GRIND_PURGE_MODE_DEFAULT);
-    grinder_purge_amount_g_for_session = GRIND_PURGE_AMOUNT_DEFAULT_G;
-    if (preferences) {
-        int purge_mode_int = preferences->getInt(PREF_KEY_GRINDER_MODE, GRIND_PURGE_MODE_DEFAULT);
-        grinder_purge_mode_for_session = static_cast<GrinderPurgeMode>(purge_mode_int);
-        float configured_amount = preferences->getFloat(PREF_KEY_GRINDER_AMOUNT_G, GRIND_PURGE_AMOUNT_DEFAULT_G);
-        configured_amount = std::clamp(configured_amount, GRIND_PURGE_AMOUNT_MIN_G, GRIND_PURGE_AMOUNT_MAX_G);
-        grinder_purge_amount_g_for_session = configured_amount;
+    LOG_BLE("[%lums CONTROLLER] start_grind() called with target=%.1fg, time=%lums, mode=%s\n",
+            millis(), target, (unsigned long)time_ms, grind_mode == GrindMode::TIME ? "TIME" : "WEIGHT");
+    if (!grinder) return;
+    if (mode == GrindMode::WEIGHT) {
+        if (!weight_sensor) return;
+        if (weight_sensor->has_hardware_fault()) {
+            LOG_BLE("ERROR: Cannot start grind - load cell hardware fault detected (%d)\n",
+                    static_cast<int>(weight_sensor->get_hardware_fault()));
+            return;
+        }
+        // Read grinder purge settings from preferences (weight mode only)
+        grinder_purge_mode_for_session = static_cast<GrinderPurgeMode>(GRIND_PURGE_MODE_DEFAULT);
+        grinder_purge_amount_g_for_session = GRIND_PURGE_AMOUNT_DEFAULT_G;
+        if (preferences) {
+            int purge_mode_int = preferences->getInt(PREF_KEY_GRINDER_MODE, GRIND_PURGE_MODE_DEFAULT);
+            grinder_purge_mode_for_session = static_cast<GrinderPurgeMode>(purge_mode_int);
+            float configured_amount = preferences->getFloat(PREF_KEY_GRINDER_AMOUNT_G, GRIND_PURGE_AMOUNT_DEFAULT_G);
+            configured_amount = std::clamp(configured_amount, GRIND_PURGE_AMOUNT_MIN_G, GRIND_PURGE_AMOUNT_MAX_G);
+            grinder_purge_amount_g_for_session = configured_amount;
+        }
     }
 
     start_time = millis();
@@ -550,7 +551,8 @@ void GrindController::update() {
 
     // Check for negative weight failsafe after TARE_CONFIRM phase during active grinding
     // Only check after motor has settled to avoid false positives from startup transients
-    if (phase != GrindPhase::COMPLETED && phase != GrindPhase::TIMEOUT &&
+    if (mode == GrindMode::WEIGHT &&
+        phase != GrindPhase::COMPLETED && phase != GrindPhase::TIMEOUT &&
         phase != GrindPhase::IDLE && phase != GrindPhase::INITIALIZING &&
         phase != GrindPhase::SETUP && phase != GrindPhase::TARING &&
         phase != GrindPhase::TARE_CONFIRM &&

--- a/src/controllers/grind_controller.cpp
+++ b/src/controllers/grind_controller.cpp
@@ -323,19 +323,15 @@ void GrindController::update() {
             break;
             
         case GrindPhase::SETUP: {
-            // Snapshot pre-tare weight so we can log the initial Cup state
             float pre_tare_weight = weight_sensor ? weight_sensor->get_weight_low_latency() : 0.0f;
-
-            // Start logging immediately (synchronous PSRAM setup only)
             grind_logger.start_grind_session(session_descriptor, pre_tare_weight);
-
-            // Initialize logging event for upcoming TARING phase
-            memset(&event_in_progress, 0, sizeof(GrindEvent));
-            if (session_descriptor.mode == GrindMode::TIME) {
-                event_in_progress.event_flags |= GRIND_EVENT_FLAG_TIME_MODE;
+            if (mode == GrindMode::TIME) {
+                if (!grinder->is_grinding()) grinder->start();
+                time_grind_start_ms = loop_data.now;
+                switch_phase(GrindPhase::TIME_GRINDING, loop_data);
+            } else {
+                switch_phase(GrindPhase::TARING, loop_data);
             }
-
-            switch_phase(GrindPhase::TARING, loop_data);
             break;
         }
             

--- a/src/hardware/WeightSensor.h
+++ b/src/hardware/WeightSensor.h
@@ -123,7 +123,7 @@ public:
     bool getTareStatus();                 // Exact HX711_ADC method
     
     // Legacy wrapper methods for compatibility
-    bool start_nonblocking_tare() { tareNoDelay(); return true; }
+    bool start_nonblocking_tare() { if (!has_hardware_fault()) { tareNoDelay(); } return true; }
     bool is_tare_in_progress() const { return doTare; }
     
     // Calibration

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,11 +82,12 @@ void setup() {
 
     // Check calibration status to determine initial screen
     bool is_calibrated = hardware_manager.get_weight_sensor()->is_calibrated();
+    GrindMode boot_grind_mode = profile_controller.get_grind_mode();
 
     if (ota_failed) {
         LOG_BLE("BOOT: Starting in OTA failure state for expected build %s\n", failed_ota_build.c_str());
         state_machine.init(UIState::OTA_UPDATE_FAILED);
-    } else if (!is_calibrated) {
+    } else if (!is_calibrated && boot_grind_mode != GrindMode::TIME) {
         LOG_BLE("BOOT: Device not calibrated - starting in CALIBRATION state\n");
         state_machine.init(UIState::CALIBRATION);
     } else {

--- a/src/ui/controllers/status_indicator_controller.cpp
+++ b/src/ui/controllers/status_indicator_controller.cpp
@@ -1,6 +1,7 @@
 #include "status_indicator_controller.h"
 
 #include "../../config/constants.h"
+#include "../../controllers/grind_mode.h"
 #include "../../system/diagnostics_controller.h"
 #include "../ui_manager.h"
 
@@ -68,6 +69,13 @@ void StatusIndicatorController::update_warning_icon() {
     // Check if there are any diagnostic warnings
     if (ui_manager_->diagnostics_controller_) {
         DiagnosticCode diagnostic = ui_manager_->diagnostics_controller_->get_highest_priority_warning();
+
+        // In TIME mode, a missing sensor is intentional — suppress the warning
+        if (diagnostic == DiagnosticCode::HX711_NOT_CONNECTED &&
+            ui_manager_->current_mode == GrindMode::TIME) {
+            diagnostic = DiagnosticCode::NONE;
+        }
+
         if (diagnostic != DiagnosticCode::NONE) {
             lv_obj_clear_flag(warning_icon_, LV_OBJ_FLAG_HIDDEN);
         } else {

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -13,6 +13,7 @@ plotly>=5.15.0
 
 # Build system (use PlatformIO from the venv, not global `pio`)
 platformio>=6.0.0
+pyyaml>=6.0.0
 
 detools>=0.53.0
 


### PR DESCRIPTION
## Summary

Enables the grinder to run in time mode when no weight sensor is connected
or responding. Previously, all grinding paths required a functioning load
cell even when weight measurement was irrelevant.

- **Bypass sensor checks in `start_grind()`** for time mode — hardware
  fault detection is now only enforced in weight mode
- **Skip TARING/TARE_CONFIRM** in time mode: the SETUP phase transitions
  directly to TIME_GRINDING, starting the motor immediately without
  attempting to tare a missing sensor
- **Boot into READY** on uncalibrated devices when time mode is selected —
  calibration is not required for time-based grinding
- **Suppress the HX711_NOT_CONNECTED warning icon** in time mode, where
  the absence of a sensor is intentional rather than a fault
- **Negative-weight failsafe** is skipped in time mode (no weight
  readings to protect against)

## Closes / Related

Closes #84 — time mode now runs entirely without tare and without any
weight sensor requirement, which is the exact use case described there.

Partially addresses #133 — time mode provides a sensor-independent
grinding path. A fully manual start/stop mode remains a separate feature.