### PR TITLE
Feature/time mode pause button

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -87,6 +87,7 @@ The platform dependency is automatically handled by PlatformIO via the `platform
 **Build production firmware:**
 ```bash
 python3 tools/grinder.py build
+# Equivalent: platformio run -e waveshare-esp32s3-touch-amoled-164
 ```
 
 **Build debug firmware:**

--- a/src/controllers/grind_controller.cpp
+++ b/src/controllers/grind_controller.cpp
@@ -109,28 +109,29 @@ void GrindController::init(WeightSensor* lc, Grinder* gr, Preferences* prefs) {
 }
 
 void GrindController::start_grind(float target, uint32_t time_ms, GrindMode grind_mode) {
-    LOG_BLE("[%lums CONTROLLER] start_grind() called with target=%.1fg, time=%lums, mode=%s\n",
-            millis(), target, (unsigned long)time_ms, grind_mode == GrindMode::TIME ? "TIME" : "WEIGHT");
-    if (!weight_sensor || !grinder) return;
-    if (weight_sensor->has_hardware_fault()) {
-        LOG_BLE("ERROR: Cannot start grind - load cell hardware fault detected (%d)\n",
-                static_cast<int>(weight_sensor->get_hardware_fault()));
-        return;
-    }
-    
     target_weight = target;
     target_time_ms = time_ms;
     mode = grind_mode;
-
-    // Read grinder purge settings from preferences (always run for weight mode)
-    grinder_purge_mode_for_session = static_cast<GrinderPurgeMode>(GRIND_PURGE_MODE_DEFAULT);
-    grinder_purge_amount_g_for_session = GRIND_PURGE_AMOUNT_DEFAULT_G;
-    if (preferences) {
-        int purge_mode_int = preferences->getInt(PREF_KEY_GRINDER_MODE, GRIND_PURGE_MODE_DEFAULT);
-        grinder_purge_mode_for_session = static_cast<GrinderPurgeMode>(purge_mode_int);
-        float configured_amount = preferences->getFloat(PREF_KEY_GRINDER_AMOUNT_G, GRIND_PURGE_AMOUNT_DEFAULT_G);
-        configured_amount = std::clamp(configured_amount, GRIND_PURGE_AMOUNT_MIN_G, GRIND_PURGE_AMOUNT_MAX_G);
-        grinder_purge_amount_g_for_session = configured_amount;
+    LOG_BLE("[%lums CONTROLLER] start_grind() called with target=%.1fg, time=%lums, mode=%s\n",
+            millis(), target, (unsigned long)time_ms, grind_mode == GrindMode::TIME ? "TIME" : "WEIGHT");
+    if (!grinder) return;
+    if (mode == GrindMode::WEIGHT) {
+        if (!weight_sensor) return;
+        if (weight_sensor->has_hardware_fault()) {
+            LOG_BLE("ERROR: Cannot start grind - load cell hardware fault detected (%d)\n",
+                    static_cast<int>(weight_sensor->get_hardware_fault()));
+            return;
+        }
+        // Read grinder purge settings from preferences (weight mode only)
+        grinder_purge_mode_for_session = static_cast<GrinderPurgeMode>(GRIND_PURGE_MODE_DEFAULT);
+        grinder_purge_amount_g_for_session = GRIND_PURGE_AMOUNT_DEFAULT_G;
+        if (preferences) {
+            int purge_mode_int = preferences->getInt(PREF_KEY_GRINDER_MODE, GRIND_PURGE_MODE_DEFAULT);
+            grinder_purge_mode_for_session = static_cast<GrinderPurgeMode>(purge_mode_int);
+            float configured_amount = preferences->getFloat(PREF_KEY_GRINDER_AMOUNT_G, GRIND_PURGE_AMOUNT_DEFAULT_G);
+            configured_amount = std::clamp(configured_amount, GRIND_PURGE_AMOUNT_MIN_G, GRIND_PURGE_AMOUNT_MAX_G);
+            grinder_purge_amount_g_for_session = configured_amount;
+        }
     }
 
     start_time = millis();
@@ -550,7 +551,8 @@ void GrindController::update() {
 
     // Check for negative weight failsafe after TARE_CONFIRM phase during active grinding
     // Only check after motor has settled to avoid false positives from startup transients
-    if (phase != GrindPhase::COMPLETED && phase != GrindPhase::TIMEOUT &&
+    if (mode == GrindMode::WEIGHT &&
+        phase != GrindPhase::COMPLETED && phase != GrindPhase::TIMEOUT &&
         phase != GrindPhase::IDLE && phase != GrindPhase::INITIALIZING &&
         phase != GrindPhase::SETUP && phase != GrindPhase::TARING &&
         phase != GrindPhase::TARE_CONFIRM &&

--- a/src/controllers/grind_controller.cpp
+++ b/src/controllers/grind_controller.cpp
@@ -323,19 +323,15 @@ void GrindController::update() {
             break;
             
         case GrindPhase::SETUP: {
-            // Snapshot pre-tare weight so we can log the initial Cup state
             float pre_tare_weight = weight_sensor ? weight_sensor->get_weight_low_latency() : 0.0f;
-
-            // Start logging immediately (synchronous PSRAM setup only)
             grind_logger.start_grind_session(session_descriptor, pre_tare_weight);
-
-            // Initialize logging event for upcoming TARING phase
-            memset(&event_in_progress, 0, sizeof(GrindEvent));
-            if (session_descriptor.mode == GrindMode::TIME) {
-                event_in_progress.event_flags |= GRIND_EVENT_FLAG_TIME_MODE;
+            if (mode == GrindMode::TIME) {
+                if (!grinder->is_grinding()) grinder->start();
+                time_grind_start_ms = loop_data.now;
+                switch_phase(GrindPhase::TIME_GRINDING, loop_data);
+            } else {
+                switch_phase(GrindPhase::TARING, loop_data);
             }
-
-            switch_phase(GrindPhase::TARING, loop_data);
             break;
         }
             

--- a/src/controllers/grind_controller.cpp
+++ b/src/controllers/grind_controller.cpp
@@ -139,6 +139,9 @@ void GrindController::start_grind(float target, uint32_t time_ms, GrindMode grin
     timeout_phase = GrindPhase::IDLE; // Initialize timeout phase
     timeout_pause_start = 0;
     timeout_offset_ms = 0;
+    grind_paused_ = false;
+    pause_start_ms_ = 0;
+    total_pause_ms_ = 0;
     last_session_result_ = GrindSessionResult::UNKNOWN;
     // Load cell now runs at constant high speed - no mode switching needed
     
@@ -281,6 +284,33 @@ void GrindController::continue_from_purge() {
     }
     time_grind_start_ms = millis();
     switch_phase(GrindPhase::PREDICTIVE);  // No loop_data needed for phase transition
+}
+
+void GrindController::pause_grind() {
+    if (phase != GrindPhase::TIME_GRINDING || grind_paused_) return;
+
+    grind_paused_ = true;
+    pause_start_ms_ = millis();
+    timeout_pause_start = pause_start_ms_;
+
+    if (grinder) grinder->stop();
+
+    LOG_BLE("[%lums CONTROLLER] Time mode grind paused\n", millis());
+}
+
+void GrindController::resume_grind() {
+    if (phase != GrindPhase::TIME_GRINDING || !grind_paused_) return;
+
+    uint32_t pause_duration = millis() - pause_start_ms_;
+    total_pause_ms_ += pause_duration;
+    timeout_offset_ms += pause_duration;
+    timeout_pause_start = 0;
+    grind_paused_ = false;
+
+    if (grinder) grinder->start();
+
+    LOG_BLE("[%lums CONTROLLER] Time mode grind resumed (paused %lums, total paused %lums)\n",
+            millis(), (unsigned long)pause_duration, (unsigned long)total_pause_ms_);
 }
 
 void GrindController::update() {
@@ -794,9 +824,11 @@ void GrindController::switch_phase(GrindPhase new_phase, const GrindLoopData& lo
 
 
 bool GrindController::check_timeout() const {
-    // Calculate elapsed time excluding paused states (like PURGE_CONFIRM)
+    // Calculate elapsed time excluding paused states (PURGE_CONFIRM and TIME mode pause)
     unsigned long elapsed_ms = millis() - start_time;
-    unsigned long active_time_ms = elapsed_ms - timeout_offset_ms;
+    unsigned long current_pause_ms = (grind_paused_ && pause_start_ms_ > 0)
+                                   ? (millis() - pause_start_ms_) : 0;
+    unsigned long active_time_ms = elapsed_ms - timeout_offset_ms - current_pause_ms;
     return active_time_ms >= (GRIND_TIMEOUT_SEC * 1000);
 }
 

--- a/src/controllers/grind_controller.h
+++ b/src/controllers/grind_controller.h
@@ -140,6 +140,11 @@ private:
     QueueHandle_t ui_event_queue;
     
     bool control_loop_paused_;      // Indicates control loop is suspended (e.g., purge confirmation)
+
+    // Time mode pause state
+    bool grind_paused_;
+    uint32_t pause_start_ms_;
+    uint32_t total_pause_ms_;
     
     // Flash operation queue - thread-safe Core 0 → Core 1 communication
     QueueHandle_t flash_op_queue;
@@ -207,6 +212,11 @@ public:
     void start_additional_pulse(); // Start an additional 100ms pulse in time mode
     bool can_pulse() const; // Check if additional pulses are allowed
     int get_additional_pulse_count() const { return additional_pulse_count; }
+
+    // Time mode pause/resume
+    void pause_grind();
+    void resume_grind();
+    bool is_grind_paused() const { return grind_paused_; }
     
     // UI event system
     void set_ui_event_callback(void (*callback)(const GrindEventData&));
@@ -225,6 +235,7 @@ public:
     
     bool is_active() const;
     bool is_control_loop_paused() const { return control_loop_paused_; }
+    GrindPhase get_phase() const { return phase; }
     float get_target_weight() const { return target_weight; }
     uint32_t get_target_time_ms() const { return target_time_ms; }
     static constexpr const char* PREF_KEY_PRIME_ENABLED = "prime_enabled";
@@ -284,10 +295,9 @@ private:
     // Internal state methods (moved from public to prevent polling)
     bool show_taring_text() const { return phase == GrindPhase::INITIALIZING || phase == GrindPhase::SETUP || phase == GrindPhase::TARING || phase == GrindPhase::TARE_CONFIRM; }
     bool is_completed() const { return phase == GrindPhase::COMPLETED; }
-    bool is_timeout() const { return phase == GrindPhase::TIMEOUT; } 
+    bool is_timeout() const { return phase == GrindPhase::TIMEOUT; }
     int get_progress_percent() const;
     float get_grind_time() const;
-    GrindPhase get_phase() const { return phase; }
     GrindPhase get_timeout_phase() const { return timeout_phase; }
     const char* get_phase_name(GrindPhase p = static_cast<GrindPhase>(-1)) const;
 

--- a/src/controllers/time_grind_strategy.cpp
+++ b/src/controllers/time_grind_strategy.cpp
@@ -27,13 +27,17 @@ bool TimeGrindStrategy::update(const GrindSessionDescriptor& session,
                 controller->time_grind_start_ms = loop_data.now;
             }
 
+            if (controller->grind_paused_) {
+                return true;
+            }
+
             if (controller->target_time_ms == 0) {
                 controller->grinder->stop();
                 controller->switch_phase(GrindPhase::FINAL_SETTLING, loop_data);
                 return true;
             }
 
-            unsigned long elapsed = loop_data.now - controller->time_grind_start_ms;
+            unsigned long elapsed = loop_data.now - controller->time_grind_start_ms - controller->total_pause_ms_;
             if (elapsed >= controller->target_time_ms) {
                 controller->grinder->stop();
                 controller->switch_phase(GrindPhase::FINAL_SETTLING, loop_data);
@@ -61,7 +65,9 @@ int TimeGrindStrategy::progress_percent(const GrindSessionDescriptor& session,
         return 0;
     }
 
-    unsigned long elapsed = millis() - controller.time_grind_start_ms;
+    unsigned long current_pause_ms = (controller.grind_paused_ && controller.pause_start_ms_ > 0)
+                                   ? (millis() - controller.pause_start_ms_) : 0;
+    unsigned long elapsed = millis() - controller.time_grind_start_ms - controller.total_pause_ms_ - current_pause_ms;
     if (elapsed >= session.target_time_ms) {
         return 100;
     }

--- a/src/hardware/WeightSensor.h
+++ b/src/hardware/WeightSensor.h
@@ -123,7 +123,7 @@ public:
     bool getTareStatus();                 // Exact HX711_ADC method
     
     // Legacy wrapper methods for compatibility
-    bool start_nonblocking_tare() { tareNoDelay(); return true; }
+    bool start_nonblocking_tare() { if (!has_hardware_fault()) { tareNoDelay(); } return true; }
     bool is_tare_in_progress() const { return doTare; }
     
     // Calibration

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,11 +82,12 @@ void setup() {
 
     // Check calibration status to determine initial screen
     bool is_calibrated = hardware_manager.get_weight_sensor()->is_calibrated();
+    GrindMode boot_grind_mode = profile_controller.get_grind_mode();
 
     if (ota_failed) {
         LOG_BLE("BOOT: Starting in OTA failure state for expected build %s\n", failed_ota_build.c_str());
         state_machine.init(UIState::OTA_UPDATE_FAILED);
-    } else if (!is_calibrated) {
+    } else if (!is_calibrated && boot_grind_mode != GrindMode::TIME) {
         LOG_BLE("BOOT: Device not calibrated - starting in CALIBRATION state\n");
         state_machine.init(UIState::CALIBRATION);
     } else {

--- a/src/ui/controllers/grinding_controller.cpp
+++ b/src/ui/controllers/grinding_controller.cpp
@@ -233,13 +233,26 @@ void GrindingUIController::handle_pulse_button() {
         return;
     }
 
-    // Check if we're in PURGE_CONFIRM phase - pulse button acts as CONTINUE
+    // PURGE_CONFIRM: pulse button acts as CONTINUE
     if (ui_manager_->purge_confirm_screen.is_visible()) {
         handle_purge_confirm_continue();
         return;
     }
 
-    // Normal time mode pulse behavior
+    // TIME_GRINDING: pulse button toggles pause/resume
+    if (ui_manager_->grind_controller->get_phase() == GrindPhase::TIME_GRINDING) {
+        if (ui_manager_->grind_controller->is_grind_paused()) {
+            LOG_BLE("[UIManager] Resume button clicked\n");
+            ui_manager_->grind_controller->resume_grind();
+        } else {
+            LOG_BLE("[UIManager] Pause button clicked\n");
+            ui_manager_->grind_controller->pause_grind();
+        }
+        update_grind_button_icon();
+        return;
+    }
+
+    // GRIND_COMPLETE: additional time mode pulse
     if (ui_manager_->grind_controller->can_pulse()) {
         LOG_BLE("[UIManager] Pulse button clicked - requesting additional pulse\n");
         ui_manager_->grind_controller->start_additional_pulse();
@@ -302,11 +315,7 @@ void GrindingUIController::update_grind_button_icon() {
         lv_obj_set_style_bg_color(grind_button_, lv_color_hex(THEME_COLOR_ERROR), 0);
     } else if (ui_manager_->state_machine->is_state(UIState::GRINDING)) {
         lv_img_set_src(grind_icon_, LV_SYMBOL_STOP);
-        lv_obj_set_style_bg_color(grind_button_,
-                                  ui_manager_->current_mode == GrindMode::TIME
-                                      ? lv_color_hex(THEME_COLOR_ACCENT)
-                                      : lv_color_hex(THEME_COLOR_PRIMARY),
-                                  0);
+        lv_obj_set_style_bg_color(grind_button_, lv_color_hex(THEME_COLOR_PRIMARY), 0);
     } else if (ui_manager_->state_machine->is_state(UIState::GRIND_COMPLETE)) {
         lv_img_set_src(grind_icon_, LV_SYMBOL_OK);
         lv_obj_set_style_bg_color(grind_button_, lv_color_hex(THEME_COLOR_SUCCESS), 0);
@@ -333,33 +342,46 @@ void GrindingUIController::update_button_layout() {
         return;
     }
 
-    // Check if we're in PURGE_CONFIRM phase (show dual buttons for CANCEL + CONTINUE)
     bool in_purge_confirm = ui_manager_->purge_confirm_screen.is_visible();
+
+    bool in_time_grinding = (ui_manager_->current_mode == GrindMode::TIME &&
+                             ui_manager_->grind_controller &&
+                             ui_manager_->grind_controller->get_phase() == GrindPhase::TIME_GRINDING &&
+                             ui_manager_->state_machine->is_state(UIState::GRINDING));
+    bool is_time_grind_paused = in_time_grinding && ui_manager_->grind_controller->is_grind_paused();
 
     bool should_show_pulse = (ui_manager_->state_machine->is_state(UIState::GRIND_COMPLETE) &&
                               ui_manager_->current_mode == GrindMode::TIME);
 
-    if (in_purge_confirm || should_show_pulse) {
-        // Dual button layout: left button at -60, right button at +60
+    if (in_purge_confirm || in_time_grinding || should_show_pulse) {
+        // Dual button layout: left=STOP/CANCEL, right=context-specific action
         lv_obj_align(grind_button_, LV_ALIGN_BOTTOM_MID, -60, -10);
         if (pulse_button_) {
             lv_obj_align(pulse_button_, LV_ALIGN_BOTTOM_MID, 60, -10);
             lv_obj_clear_flag(pulse_button_, LV_OBJ_FLAG_HIDDEN);
 
             if (in_purge_confirm) {
-                // Purge confirm: pulse button acts as CONTINUE (always enabled)
                 lv_img_set_src(pulse_icon_, LV_SYMBOL_OK);
                 lv_obj_set_style_bg_color(pulse_button_, lv_color_hex(THEME_COLOR_SUCCESS), 0);
                 lv_obj_clear_state(pulse_button_, LV_STATE_DISABLED);
                 lv_obj_set_style_bg_opa(pulse_button_, LV_OPA_COVER, 0);
+            } else if (in_time_grinding) {
+                // Pause / Resume toggle
+                if (is_time_grind_paused) {
+                    lv_img_set_src(pulse_icon_, LV_SYMBOL_PLAY);
+                    lv_obj_set_style_bg_color(pulse_button_, lv_color_hex(THEME_COLOR_SUCCESS), 0);
+                } else {
+                    lv_img_set_src(pulse_icon_, LV_SYMBOL_PAUSE);
+                    lv_obj_set_style_bg_color(pulse_button_, lv_color_hex(THEME_COLOR_ACCENT), 0);
+                }
+                lv_obj_clear_state(pulse_button_, LV_STATE_DISABLED);
+                lv_obj_set_style_bg_opa(pulse_button_, LV_OPA_COVER, 0);
             } else if (ui_manager_->grind_controller && ui_manager_->grind_controller->can_pulse()) {
-                // Time mode pulse: enable/disable based on can_pulse()
                 lv_img_set_src(pulse_icon_, LV_SYMBOL_PLUS);
                 lv_obj_set_style_bg_color(pulse_button_, lv_color_hex(THEME_COLOR_ACCENT), 0);
                 lv_obj_clear_state(pulse_button_, LV_STATE_DISABLED);
                 lv_obj_set_style_bg_opa(pulse_button_, LV_OPA_COVER, 0);
             } else {
-                // Time mode pulse: disabled
                 lv_img_set_src(pulse_icon_, LV_SYMBOL_PLUS);
                 lv_obj_set_style_bg_color(pulse_button_, lv_color_hex(THEME_COLOR_ACCENT), 0);
                 lv_obj_add_state(pulse_button_, LV_STATE_DISABLED);
@@ -367,7 +389,7 @@ void GrindingUIController::update_button_layout() {
             }
         }
     } else {
-        // Single button layout: centered at 0
+        // Single button layout: centered
         lv_obj_align(grind_button_, LV_ALIGN_BOTTOM_MID, 0, -10);
         if (pulse_button_) {
             lv_obj_add_flag(pulse_button_, LV_OBJ_FLAG_HIDDEN);
@@ -439,6 +461,14 @@ void GrindingUIController::handle_grind_event(const GrindEventData& event_data) 
 
             if (ui_manager_->state_machine->is_state(UIState::GRIND_COMPLETE)) {
                 update_button_layout();
+            }
+
+            // Update button layout when phase changes within TIME mode GRINDING
+            // (e.g. entering/exiting TIME_GRINDING to show/hide pause button)
+            if (event_data.mode == GrindMode::TIME &&
+                ui_manager_->state_machine->is_state(UIState::GRINDING) &&
+                event_data.phase != GrindPhase::PURGE_CONFIRM) {
+                update_grind_button_icon();
             }
 
             if (event_data.show_taring_text) {

--- a/src/ui/controllers/status_indicator_controller.cpp
+++ b/src/ui/controllers/status_indicator_controller.cpp
@@ -1,6 +1,7 @@
 #include "status_indicator_controller.h"
 
 #include "../../config/constants.h"
+#include "../../controllers/grind_mode.h"
 #include "../../system/diagnostics_controller.h"
 #include "../ui_manager.h"
 
@@ -68,6 +69,13 @@ void StatusIndicatorController::update_warning_icon() {
     // Check if there are any diagnostic warnings
     if (ui_manager_->diagnostics_controller_) {
         DiagnosticCode diagnostic = ui_manager_->diagnostics_controller_->get_highest_priority_warning();
+
+        // In TIME mode, a missing sensor is intentional — suppress the warning
+        if (diagnostic == DiagnosticCode::HX711_NOT_CONNECTED &&
+            ui_manager_->current_mode == GrindMode::TIME) {
+            diagnostic = DiagnosticCode::NONE;
+        }
+
         if (diagnostic != DiagnosticCode::NONE) {
             lv_obj_clear_flag(warning_icon_, LV_OBJ_FLAG_HIDDEN);
         } else {

--- a/src/ui/screens/grinding_screen_arc.cpp
+++ b/src/ui/screens/grinding_screen_arc.cpp
@@ -57,6 +57,7 @@ void GrindingScreenArc::create() {
 
     visible = false;
     time_mode = false;
+    target_time_seconds_ = 0.0f;
     lv_obj_add_flag(screen, LV_OBJ_FLAG_HIDDEN);
 }
 
@@ -88,6 +89,7 @@ void GrindingScreenArc::update_target_weight_text(const char* text) {
 }
 
 void GrindingScreenArc::update_target_time(float seconds) {
+    target_time_seconds_ = seconds;
     char target_text[32];
     snprintf(target_text, sizeof(target_text), "Time: %.1fs", seconds);
     lv_label_set_text(target_label, target_text);
@@ -106,6 +108,13 @@ void GrindingScreenArc::update_tare_display() {
 
 void GrindingScreenArc::update_progress(int percent) {
     lv_arc_set_value(progress_arc, percent);
+    if (time_mode && target_time_seconds_ > 0.0f) {
+        // Show elapsed time in center instead of sensor weight
+        float elapsed_s = (percent / 100.0f) * target_time_seconds_;
+        char elapsed_text[16];
+        snprintf(elapsed_text, sizeof(elapsed_text), "%.1fs", elapsed_s);
+        lv_label_set_text(weight_label, elapsed_text);
+    }
 }
 
 void GrindingScreenArc::set_time_mode(bool enabled) {

--- a/src/ui/screens/grinding_screen_arc.h
+++ b/src/ui/screens/grinding_screen_arc.h
@@ -12,6 +12,7 @@ private:
     lv_obj_t* progress_arc;
     bool visible;
     bool time_mode;
+    float target_time_seconds_;
 
 public:
     void create() override;

--- a/src/ui/screens/grinding_screen_chart.cpp
+++ b/src/ui/screens/grinding_screen_chart.cpp
@@ -238,8 +238,17 @@ void GrindingScreenChart::update_tare_display() {
 }
 
 void GrindingScreenChart::update_progress(int percent) {
-    // Progress is now visualized through the chart data
-    // This method is kept for compatibility but chart updates happen via add_chart_data_point
+    if (time_mode && target_time_seconds > 0.0f) {
+        // Show elapsed time in current value display instead of sensor weight
+        lv_span_t* current_span = lv_spangroup_get_child(weight_spangroup, 0);
+        if (current_span) {
+            float elapsed_s = (percent / 100.0f) * target_time_seconds;
+            char elapsed_text[16];
+            snprintf(elapsed_text, sizeof(elapsed_text), "%.1fs", elapsed_s);
+            lv_span_set_text(current_span, elapsed_text);
+            lv_spangroup_refresh(weight_spangroup);
+        }
+    }
 }
 
 void GrindingScreenChart::add_chart_data_point(float current_weight, float flow_rate, uint32_t current_time_ms) {

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -13,6 +13,7 @@ plotly>=5.15.0
 
 # Build system (use PlatformIO from the venv, not global `pio`)
 platformio>=6.0.0
+pyyaml>=6.0.0
 
 detools>=0.53.0
 


### PR DESCRIPTION
## Summary

- Adds a **PAUSE button** alongside the STOP button during TIME mode grinding. Pressing Pause halts the motor and freezes the timer; the button switches to RESUME (green). Pressing Resume restarts the motor and continues from exactly where it left off.
- The elapsed time display in the arc and chart screens now shows **actual grinding time** (`"15.3s"`) in TIME mode instead of sensor weight — meaning it correctly freezes during pause, works without a weight sensor, and is unaffected by motor-vibration artefacts in the load cell reading.
- Timeout and elapsed-time calculations **exclude in-progress pause durations**, so pausing for any length of time will never trigger the 30-second grind timeout.

## Technical details

**Controller layer**
- `GrindController`: new `pause_grind()` / `resume_grind()` public methods; private `grind_paused_`, `pause_start_ms_`, `total_pause_ms_` state; `get_phase()` promoted to public so the UI can query it directly.
- `check_timeout()`: dynamically subtracts the currently-running pause duration from active time, so the timeout stays frozen while paused.
- `TimeGrindStrategy`: freezes the control loop when `grind_paused_` is true; both `update()` and `progress_percent()` subtract accumulated + in-progress pause time from elapsed.

**UI layer**
- During `TIME_GRINDING`, `update_button_layout()` switches to the dual-button layout (STOP left, PAUSE/RESUME right). The right button shows a blue pause icon while active and a green play icon while paused.
- `handle_pulse_button()` now handles the pause/resume toggle as a priority path before the existing pulse logic.
- `PHASE_CHANGED` events within an active `GRINDING` state trigger `update_grind_button_icon()`, so the pause button appears and disappears at the right phase transitions.
- `GrindingScreenArc` and `GrindingScreenChart` override `update_progress()` in TIME mode to derive and display elapsed seconds (`progress_percent × target_time`), replacing the sensor weight value in the centre display.