### PR TITLE
Add Waveshare 1.64-inch V2 hardware support

### DIFF
--- a/.github/workflows/deploy-web-flasher.yml
+++ b/.github/workflows/deploy-web-flasher.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'tools/web-flasher/**'  # Deploy when web-flasher files change (after firmware commit)
   release:
-    types: [ unpublished, deleted ]
+    types: [ published, unpublished, deleted ]
   workflow_dispatch:
 
 permissions:
@@ -67,59 +67,42 @@ jobs:
           if True:
               import json
               import os
-              import time
-              import urllib.request
 
               firmware_root = "tools/web-flasher/firmware"
               entries = []
-
-              def wait_for(url, retries=30, delay=30):
-                  for attempt in range(retries):
-                      try:
-                          with urllib.request.urlopen(url) as response:
-                              if response.status == 200:
-                                  print(f"  [OK] {url} (attempt {attempt + 1})")
-                                  return True
-                      except Exception:
-                          print(f"  [WAIT] {url} (attempt {attempt + 1})")
-                      time.sleep(delay)
-                  total = retries * delay
-                  minutes = total // 60
-                  print(f"  [FAIL] {url} after {retries} attempts (~{minutes}m)")
-                  return False
 
               for tag in sorted(os.listdir(firmware_root), reverse=True):
                   tag_path = os.path.join(firmware_root, tag)
                   if not os.path.isdir(tag_path):
                       continue
 
-                  base = f"smart-grind-by-weight-{tag}"
-                  manifest_rel = f"firmware/{tag}/{base}.manifest.json"
-                  ota_rel = f"firmware/{tag}/{base}-web-ota.bin"
-
-                  manifest_abs = os.path.join(tag_path, f"{base}.manifest.json")
-                  ota_abs = os.path.join(tag_path, f"{base}-web-ota.bin")
-
-                  if not (os.path.isfile(manifest_abs) and os.path.isfile(ota_abs)):
-                      continue
-
                   prerelease = any(key in tag for key in ("-rc", "-beta", "-alpha"))
                   version = tag.lstrip('v')
+                  base = f"smart-grind-by-weight-{tag}"
+                  variants = (
+                      ("Waveshare 1.64 V1", base),
+                      ("Waveshare 1.64 V2", f"{base}-waveshare-164-v2"),
+                  )
 
-                  manifest_url = f"https://jaapp.github.io/smart-grind-by-weight/{manifest_rel}"
-                  ota_url = f"https://jaapp.github.io/smart-grind-by-weight/{ota_rel}"
+                  for board, artifact_base in variants:
+                      manifest_rel = f"firmware/{tag}/{artifact_base}.manifest.json"
+                      ota_rel = f"firmware/{tag}/{artifact_base}-web-ota.bin"
+                      manifest_abs = os.path.join(tag_path, f"{artifact_base}.manifest.json")
+                      ota_abs = os.path.join(tag_path, f"{artifact_base}-web-ota.bin")
 
-                  if not wait_for(manifest_url) or not wait_for(ota_url):
-                      continue
+                      # Older releases contain only the original V1 artifact.
+                      if not (os.path.isfile(manifest_abs) and os.path.isfile(ota_abs)):
+                          continue
 
-                  entries.append({
-                      "tag": tag,
-                      "version": version,
-                      "display": tag,
-                      "prerelease": prerelease,
-                      "manifest": manifest_rel,
-                      "ota": ota_rel,
-                  })
+                      entries.append({
+                          "tag": tag,
+                          "version": version,
+                          "board": board,
+                          "display": f"{tag} - {board}",
+                          "prerelease": prerelease,
+                          "manifest": manifest_rel,
+                          "ota": ota_rel,
+                      })
 
               index_path = os.path.join(firmware_root, "index.json")
               with open(index_path, "w", encoding="utf-8") as handle:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,8 +149,10 @@ jobs:
           **Note:** Requires Chrome/Edge (desktop or Android). iOS/Safari not supported.
 
           ### Command Line (Alternative)
-          1. Download \`smart-grind-by-weight-${{ github.ref_name }}.bin\` below
-          2. Use the grinder tool to upload: \`python3 tools/grinder.py upload smart-grind-by-weight-${{ github.ref_name }}.bin\`
+          1. Download the firmware matching your board revision:
+             - V1: \`smart-grind-by-weight-${{ github.ref_name }}.bin\`
+             - V2: \`smart-grind-by-weight-${{ github.ref_name }}-waveshare-164-v2.bin\`
+          2. Use the grinder tool to upload the selected file, for example: \`python3 tools/grinder.py upload <firmware-file>.bin\`
 
           ## Build Information
           - Build Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
           # Install dependencies first to ensure exact versions
           pio pkg install
           pio run -e waveshare-esp32s3-touch-amoled-164
+          pio run -e waveshare-esp32s3-touch-amoled-164-v2
         
       - name: Prepare release artifacts
         run: |
@@ -44,6 +45,9 @@ jobs:
           cp .pio/build/waveshare-esp32s3-touch-amoled-164/firmware.bin release-artifacts/smart-grind-by-weight-${VERSION}.bin
           cp .pio/build/waveshare-esp32s3-touch-amoled-164/bootloader.bin release-artifacts/smart-grind-by-weight-${VERSION}-bootloader.bin
           cp .pio/build/waveshare-esp32s3-touch-amoled-164/partitions.bin release-artifacts/smart-grind-by-weight-${VERSION}-partitions.bin
+          cp .pio/build/waveshare-esp32s3-touch-amoled-164-v2/firmware.bin release-artifacts/smart-grind-by-weight-${VERSION}-waveshare-164-v2.bin
+          cp .pio/build/waveshare-esp32s3-touch-amoled-164-v2/bootloader.bin release-artifacts/smart-grind-by-weight-${VERSION}-waveshare-164-v2-bootloader.bin
+          cp .pio/build/waveshare-esp32s3-touch-amoled-164-v2/partitions.bin release-artifacts/smart-grind-by-weight-${VERSION}-waveshare-164-v2-partitions.bin
 
           # Create blank 8KB NVS partition file (0xe000 to 0x10000)
           dd if=/dev/zero of=release-artifacts/blank_8KB.bin bs=8192 count=1
@@ -54,6 +58,8 @@ jobs:
           touch empty.bin
           detools create_patch -c heatshrink empty.bin "release-artifacts/smart-grind-by-weight-${VERSION}.bin" "release-artifacts/smart-grind-by-weight-${VERSION}-web-ota.bin"
           echo "Web OTA patch created: smart-grind-by-weight-${VERSION}-web-ota.bin ($(du -h "release-artifacts/smart-grind-by-weight-${VERSION}-web-ota.bin" | cut -f1))"
+          echo "Generating V2 web OTA patch"
+          detools create_patch -c heatshrink empty.bin "release-artifacts/smart-grind-by-weight-${VERSION}-waveshare-164-v2.bin" "release-artifacts/smart-grind-by-weight-${VERSION}-waveshare-164-v2-web-ota.bin"
 
           # Generate manifest file
           echo "Generating manifest file..."
@@ -93,6 +99,39 @@ jobs:
           EOF
           echo "Generated manifest: smart-grind-by-weight-${VERSION}.manifest.json"
 
+          cat > "smart-grind-by-weight-${VERSION}-waveshare-164-v2.manifest.json" << EOF
+          {
+            "name": "Smart Grind By Weight - Waveshare 1.64 V2",
+            "version": "${VERSION_NUMBER}",
+            "home_assistant_domain": "grinder",
+            "new_install_skip_erase": true,
+            "builds": [
+              {
+                "chipFamily": "ESP32-S3",
+                "parts": [
+                  {
+                    "path": "smart-grind-by-weight-${VERSION}-waveshare-164-v2-bootloader.bin",
+                    "offset": 0
+                  },
+                  {
+                    "path": "smart-grind-by-weight-${VERSION}-waveshare-164-v2-partitions.bin",
+                    "offset": 32768
+                  },
+                  {
+                    "path": "blank_8KB.bin",
+                    "offset": 57344
+                  },
+                  {
+                    "path": "smart-grind-by-weight-${VERSION}-waveshare-164-v2.bin",
+                    "offset": 3276800
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+          echo "Generated V2 manifest: smart-grind-by-weight-${VERSION}-waveshare-164-v2.manifest.json"
+
           # Create a firmware package
           tar -czf smart-grind-by-weight-${VERSION}.tar.gz *.bin *.manifest.json
           cd ..
@@ -105,7 +144,7 @@ jobs:
           ## Installation
 
           ### Web Installer (Recommended)
-          Visit [Web Installer](https://jaapp.github.io/smart-grind-by-weight/) and select firmware version ${{ github.ref_name }}
+          Visit [Web Installer](https://jaapp.github.io/smart-grind-by-weight/) and select firmware version ${{ github.ref_name }} for your Waveshare V1 or V2 board revision.
 
           **Note:** Requires Chrome/Edge (desktop or Android). iOS/Safari not supported.
 
@@ -168,10 +207,4 @@ jobs:
           IS_PRERELEASE=${IS_PRERELEASE:-false}
 
           echo "Uploading firmware assets for $TAG (prerelease: ${IS_PRERELEASE})"
-          gh release upload "$TAG" "release-artifacts/smart-grind-by-weight-${TAG}.bin" --clobber
-          gh release upload "$TAG" "release-artifacts/smart-grind-by-weight-${TAG}-bootloader.bin" --clobber
-          gh release upload "$TAG" "release-artifacts/smart-grind-by-weight-${TAG}-partitions.bin" --clobber
-          gh release upload "$TAG" "release-artifacts/smart-grind-by-weight-${TAG}-web-ota.bin" --clobber
-          gh release upload "$TAG" "release-artifacts/smart-grind-by-weight-${TAG}.manifest.json" --clobber
-          gh release upload "$TAG" "release-artifacts/blank_8KB.bin" --clobber
-          gh release upload "$TAG" "release-artifacts/smart-grind-by-weight-${TAG}.tar.gz" --clobber
+          gh release upload "$TAG" release-artifacts/* --clobber

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ flowchart LR
 
 1. **Get the parts** - ESP32-S3 AMOLED display + HX711 + load cell (~€35 total) → See [Parts List](docs/DOC.md#-parts-list)
 2. **3D print the mounting parts** - All STL files included, no supports needed → See [3D Printed Parts](docs/DOC.md#3d-printed-parts) | [Community Designs](docs/3D_PRINTS.md)
-3. **Check your board revision, then flash & calibrate** - The 1.64-inch board has incompatible V1 and V2 displays. See [Display stays black after flashing](docs/TROUBLESHOOTING.md#display-stays-black-after-flashing-waveshare-164-v2), then use the [Web Flasher](https://jaapp.github.io/smart-grind-by-weight) (Chrome/Edge desktop + Android only) or command line
+3. **Check your board revision, wiring, then flash & calibrate** - The 1.64-inch board has incompatible V1 and V2 display firmware and different external GPIO assignments. V2 uses GPIO 1 for HX711 SCK and GPIO 16 for motor control. See [Display stays black after flashing](docs/TROUBLESHOOTING.md#display-stays-black-after-flashing-waveshare-164-v2), then choose the matching V1/V2 image in the [Web Flasher](https://jaapp.github.io/smart-grind-by-weight) (Chrome/Edge desktop + Android only) or build the matching command-line target
 4. **Follow the assembly video** - [Complete Eureka build process](https://youtu.be/-kfKjiwJsGM)
 
 **Ready to build?** → See **[DOC.md](docs/DOC.md)** for complete build instructions, parts list, and usage guide.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ flowchart LR
 
 1. **Get the parts** - ESP32-S3 AMOLED display + HX711 + load cell (~€35 total) → See [Parts List](docs/DOC.md#-parts-list)
 2. **3D print the mounting parts** - All STL files included, no supports needed → See [3D Printed Parts](docs/DOC.md#3d-printed-parts) | [Community Designs](docs/3D_PRINTS.md)
-3. **Flash firmware & calibrate** - [Web Flasher](https://jaapp.github.io/smart-grind-by-weight) (Chrome/Edge desktop + Android only) or command line
+3. **Check your board revision, then flash & calibrate** - The 1.64-inch board has incompatible V1 and V2 displays. See [Display stays black after flashing](docs/TROUBLESHOOTING.md#display-stays-black-after-flashing-waveshare-164-v2), then use the [Web Flasher](https://jaapp.github.io/smart-grind-by-weight) (Chrome/Edge desktop + Android only) or command line
 4. **Follow the assembly video** - [Complete Eureka build process](https://youtu.be/-kfKjiwJsGM)
 
 **Ready to build?** → See **[DOC.md](docs/DOC.md)** for complete build instructions, parts list, and usage guide.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -34,13 +34,18 @@ This automatically creates a virtual environment and installs all required depen
 
 ## 🔧 Build Targets
 
-The project has three build targets:
+The project has four build targets:
 
 ### Production Target: `waveshare-esp32s3-touch-amoled-164`
-- **Use case:** Real hardware with load cell and grinder connected
+- **Use case:** Real V1 hardware with load cell and grinder connected
 - **Hardware:** Full ESP32-S3 + HX711 + load cell + grinder motor relay
 - **Features:** All functionality enabled
 - **Optimizations:** `-Ofast` optimization level for performance
+
+### V2 Production Target: `waveshare-esp32s3-touch-amoled-164-v2`
+- **Use case:** Waveshare 1.64-inch V2 hardware with load cell and grinder connected
+- **Display:** SH8601 using Waveshare's native `esp_lcd` QSPI driver
+- **Important:** V1 and V2 display firmware is not interchangeable; the wrong target normally boots to a black screen
 
 ### Debug Target: `waveshare-esp32s3-touch-amoled-164-debug`
 - **Use case:** Development and debugging with real hardware
@@ -89,6 +94,11 @@ The platform dependency is automatically handled by PlatformIO via the `platform
 python3 tools/grinder.py build
 ```
 
+**Build V2 production firmware:**
+```bash
+python3 tools/venv/bin/python -m platformio run -e waveshare-esp32s3-touch-amoled-164-v2
+```
+
 **Build debug firmware:**
 ```bash
 python3 tools/venv/bin/python -m platformio run -e waveshare-esp32s3-touch-amoled-164-debug
@@ -112,6 +122,9 @@ For the first-time setup or when BLE isn't working:
 # Build and upload via USB (production)
 python3 tools/grinder.py build
 python3 tools/venv/bin/python -m platformio run --target upload -e waveshare-esp32s3-touch-amoled-164
+
+# Or for the V2 hardware revision
+python3 tools/venv/bin/python -m platformio run --target upload -e waveshare-esp32s3-touch-amoled-164-v2
 
 # Or for debug target
 python3 tools/venv/bin/python -m platformio run --target upload -e waveshare-esp32s3-touch-amoled-164-debug

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -45,6 +45,7 @@ The project has four build targets:
 ### V2 Production Target: `waveshare-esp32s3-touch-amoled-164-v2`
 - **Use case:** Waveshare 1.64-inch V2 hardware with load cell and grinder connected
 - **Display:** SH8601 using Waveshare's native `esp_lcd` QSPI driver
+- **External GPIO:** HX711 SCK on GPIO 1; grinder motor control on GPIO 16 (GPIO 18 is reserved by `TP_INT`)
 - **Important:** V1 and V2 display firmware is not interchangeable; the wrong target normally boots to a black screen
 
 ### Debug Target: `waveshare-esp32s3-touch-amoled-164-debug`

--- a/docs/DOC.md
+++ b/docs/DOC.md
@@ -49,7 +49,7 @@ Complete build instructions, parts list, and usage guide for the Smart Grind-by-
 
 > **Note:** All links are **for reference only** — sellers and items are **not personally verified** unless explicitly stated.
 
-- **[Waveshare ESP32-S3 1.64" AMOLED Touch Display](https://www.waveshare.com/esp32-s3-touch-amoled-1.64.htm)** — Main controller
+- **[Waveshare ESP32-S3 1.64" AMOLED Touch Display](https://www.waveshare.com/esp32-s3-touch-amoled-1.64.htm)** — Main controller. Waveshare has shipped incompatible V1 and V2 display revisions; confirm the revision before flashing.
 - **[HX711 ADC module](https://nl.aliexpress.com/item/1005006851380544.html)** — Load cell amplifier
 - **MAVIN or T70 load cell** (0.3 – 1 kg range) — Weight sensor
   ⚠️ Avoid cheap unshielded small load cells — accuracy will suffer
@@ -202,8 +202,16 @@ ESP32-S3 GND       →    Pin 4 (Ground)
 
 ## 🚀 Firmware Installation
 
+### Check the display revision first
+
+The 1.64-inch Waveshare board now exists in two firmware-incompatible revisions. V1 uses the original CO5300 display path; V2 uses an SH8601 controller, GPIO 46 chip select, and a 20-pixel framebuffer offset. Firmware built for the wrong revision can boot normally while the AMOLED remains completely black.
+
+If the board was supplied with V2 factory firmware, or Waveshare's [official V2 demo](https://github.com/waveshareteam/ESP32-S3-Touch-AMOLED-1.64-v2) works while V1 firmware stays black, use the V2 build target. See the [black-display troubleshooting entry](TROUBLESHOOTING.md#display-stays-black-after-flashing-waveshare-164-v2) before wiring the grinder.
+
 ### 🌐 Web Flasher (Recommended)
 **[🔗 Open Web Flasher Tool](https://jaapp.github.io/smart-grind-by-weight)**
+
+Before flashing, verify that the selected image matches your V1 or V2 hardware revision. If the flasher does not yet list a V2 image, build the `waveshare-esp32s3-touch-amoled-164-v2` source target instead; flashing the V1 image to V2 produces a black screen.
 
 **Browser Compatibility:**
 - ✅ **Chrome** (Desktop & Android) - Full support

--- a/docs/DOC.md
+++ b/docs/DOC.md
@@ -121,7 +121,7 @@ Watch the complete Eureka Mignon Specialita assembly process: **[YouTube Assembl
 
 **HX711 Load Cell Amplifier Connections:**
 ```
-ESP32-S3 GPIO 2    →    HX711 SCK
+ESP32-S3 GPIO 2 (V1) / GPIO 1 (V2) → HX711 SCK
 ESP32-S3 GPIO 3    →    HX711 DOUT
 ESP32-S3 3.3V      →    HX711 VCC
 ESP32-S3 GND       →    HX711 GND
@@ -163,17 +163,20 @@ Using the 4-pin Eureka plug pinout (see `../media/4-pin_Eureka_plug_pinout.png`)
 ```
 ESP32-S3 5V        →    Pin 1 (5V power)
                         Pin 2 (Button signal - not used in this project)
-ESP32-S3 GPIO 18   →    Pin 3 (Motor control signal)
+ESP32-S3 GPIO 18 (V1) / GPIO 16 (V2) → Pin 3 (Motor control signal)
 ESP32-S3 GND       →    Pin 4 (Ground)
 ```
 
 **4-Pin Eureka Plug Reference (Left to Right):**
 - **Pin 1**: 5V power supply
 - **Pin 2**: Button signal (unused in this project)  
-- **Pin 3**: Motor control signal *(active-high — the motor runs when GPIO 18 drives this pin to ~3.3V)*
+- **Pin 3**: Motor control signal *(active-high — the motor runs when the revision-specific GPIO drives this pin to ~3.3V)*
 - **Pin 4**: Ground
 
-⚠️ **VERIFY 5V:** Use a multimeter to confirm 5V pin - wire colors vary between units! The Waveshare board has reverse polarity protection, and button/motor wires can be swapped without risk of damage.
+> [!WARNING]
+> On V2, do not connect motor control to GPIO 18. It is shared with the touchscreen interrupt (`TP_INT`) and its pull-up circuitry can leak voltage into the grinder control input. The physically verified V2 wiring uses GPIO 16 for motor control and GPIO 1 for HX711 SCK.
+
+⚠️ **VERIFY 5V:** Use a multimeter to confirm the 5V pin and identify the motor lead by plug position, not colour. In the verified V2 Specialita installation, Pin 3 (motor control) was the **grey** wire and Pin 2 (unused button signal) was **white**; an earlier assumption had these reversed. Wire colours can differ between grinder revisions, so treat this only as a checked example and leave Pin 2 disconnected and insulated.
 
 ### Installation Steps
 
@@ -205,6 +208,8 @@ ESP32-S3 GND       →    Pin 4 (Ground)
 ### Check the display revision first
 
 The 1.64-inch Waveshare board now exists in two firmware-incompatible revisions. V1 uses the original CO5300 display path; V2 uses an SH8601 controller, GPIO 46 chip select, and a 20-pixel framebuffer offset. Firmware built for the wrong revision can boot normally while the AMOLED remains completely black.
+
+The external wiring also differs: V1 uses GPIO 2 for HX711 SCK and GPIO 18 for motor control; V2 uses GPIO 1 for HX711 SCK and GPIO 16 for motor control. Select the correct firmware target and follow the matching wiring before powering the grinder.
 
 If the board was supplied with V2 factory firmware, or Waveshare's [official V2 demo](https://github.com/waveshareteam/ESP32-S3-Touch-AMOLED-1.64-v2) works while V1 firmware stays black, use the V2 build target. See the [black-display troubleshooting entry](TROUBLESHOOTING.md#display-stays-black-after-flashing-waveshare-164-v2) before wiring the grinder.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -3,12 +3,41 @@
 ## Table of Contents
 
 - [Motor Does Not Start](#motor-does-not-start)
+- [Display Stays Black After Flashing (Waveshare 1.64 V2)](#display-stays-black-after-flashing-waveshare-164-v2)
 - [HX711 Not Detected / Wrong Sample Rate](#hx711-not-detected--wrong-sample-rate)
 - [Unknown board ID 'esp32-s3-devkitc-1'](#unknown-board-id-esp32-s3-devkitc-1)
 - [PlatformIO Project Initialization Issues](#platformio-project-initialization-issues)
 - [Grind Timeout Screen](#grind-timeout-screen)
 - [Unreliable Pulse Corrections](#unreliable-pulse-corrections)
 - [Getting Diagnostic Reports](#getting-diagnostic-reports)
+
+---
+
+## Display Stays Black After Flashing (Waveshare 1.64 V2)
+
+**Applies to:** ESP32-S3-Touch-AMOLED-1.64 boards that still accept firmware and produce serial/BLE diagnostics, but show no pixels after Smart Grind starts.
+
+### Symptoms
+- The display worked with the factory firmware, then became completely black after flashing Smart Grind.
+- The device still boots, connects, or produces a diagnostic report.
+- Reflashing the official V2 demo restores the display.
+
+### Root Cause
+Waveshare's V2 revision is not display-compatible with the original board. It uses an SH8601 panel controller, GPIO 46 for display chip select, a 40 MHz QSPI bus, and a 20-pixel X offset. The original V1 target uses a different display path and can boot successfully without lighting a V2 panel.
+
+### Confirm the Revision
+Flash Waveshare's [official V2 demo](https://github.com/waveshareteam/ESP32-S3-Touch-AMOLED-1.64-v2). If that works but the V1 demo or normal Smart Grind image remains black, treat the board as V2. Do this test before connecting the grinder wiring so display compatibility is isolated from the rest of the installation.
+
+### Resolution
+Build and flash the V2 target:
+
+```bash
+python3 tools/venv/bin/python -m platformio run --target upload -e waveshare-esp32s3-touch-amoled-164-v2
+```
+
+Do not change only the chip-select pin in a V1 build. Hardware validation showed that an Arduino_GFX SH8601 attempt remained black; the working V2 target uses Waveshare's native Espressif `esp_lcd` SH8601 driver and initialization sequence.
+
+If using the Web Flasher, select an image explicitly labelled for the 1.64-inch V2 board. If no V2 image is listed, do not flash the V1 image; build the V2 target from source or wait for a V2 release artifact.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -35,6 +35,8 @@ Build and flash the V2 target:
 python3 tools/venv/bin/python -m platformio run --target upload -e waveshare-esp32s3-touch-amoled-164-v2
 ```
 
+For a complete V2 installation, wire HX711 SCK to GPIO 1 and the grinder motor-control lead to GPIO 16. GPIO 18 is connected to the V2 touchscreen interrupt (`TP_INT`) and must not be used for motor control. The V1 connections remain HX711 SCK on GPIO 2 and motor control on GPIO 18.
+
 Do not change only the chip-select pin in a V1 build. Hardware validation showed that an Arduino_GFX SH8601 attempt remained black; the working V2 target uses Waveshare's native Espressif `esp_lcd` SH8601 driver and initialization sequence.
 
 If using the Web Flasher, select an image explicitly labelled for the 1.64-inch V2 board. If no V2 image is listed, do not flash the V1 image; build the V2 target from source or wait for a V2 release artifact.
@@ -81,12 +83,12 @@ The motor control wire (Pin 3) is the wire that **starts the motor when briefly 
 ### Resolution
 
 **Swap the wire connections:**
-- The motor control wire (Pin 3) should connect to Waveshare **GPIO 18**
+- The motor control wire (Pin 3) should connect to Waveshare **GPIO 18 on V1** or **GPIO 16 on V2**
 - The button signal wire (Pin 2) can remain disconnected (unused in this project)
 
-If wires were reversed, swap them so Pin 3 connects to GPIO 18. The Waveshare board has reverse polarity protection for power connections, but the motor/button wires should be correctly identified for proper operation.
+If wires were reversed, swap them so Pin 3 connects to the correct GPIO for the board revision. On V2, never use GPIO 18 for motor control because it is shared with `TP_INT`. The Waveshare board has reverse polarity protection for power connections, but the motor/button wires should be correctly identified for proper operation.
 
-**Important:** Wire colors vary significantly between Eureka units - always refer to pin positions rather than wire colors when troubleshooting.
+**Important:** Wire colors vary significantly between Eureka units - always refer to pin positions rather than wire colors when troubleshooting. On the physically verified V2 Specialita, Pin 3 was the grey lead and Pin 2 was white, contrary to the earlier assumed assignment; the white Pin 2 lead was left disconnected and insulated.
 
 ---
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -66,6 +66,12 @@ monitor_filters = esp32_exception_decoder, default, hiding_filter
 monitor_options =
     --filter hiding_filter:--regex ".*i2cWriteReadNonStop.*" --invert
 
+[env:waveshare-esp32s3-touch-amoled-164-v2]
+extends = env:waveshare-esp32s3-touch-amoled-164
+build_flags =
+    ${env:waveshare-esp32s3-touch-amoled-164.build_flags}
+    -DHW_DISPLAY_VARIANT_V2=1
+
 [env:waveshare-esp32s3-touch-amoled-164-mock]
 extends = env:waveshare-esp32s3-touch-amoled-164-debug
 

--- a/src/config/hardware.h
+++ b/src/config/hardware.h
@@ -35,10 +35,18 @@
 
 // Load Cell ADC Pins
 #define HW_LOADCELL_DOUT_PIN 3                                                 // HX711 data output pin
-#define HW_LOADCELL_SCK_PIN 2                                                  // HX711 serial clock pin
+#if HW_DISPLAY_VARIANT_V2
+#define HW_LOADCELL_SCK_PIN 1                                                  // V2 wiring; GPIO2 is bypassed on this board revision
+#else
+#define HW_LOADCELL_SCK_PIN 2                                                  // V1 HX711 serial clock pin
+#endif
 
 // Motor Control
-#define HW_MOTOR_RELAY_PIN 18                                                  // GPIO pin for grinder motor control relay
+#if HW_DISPLAY_VARIANT_V2
+#define HW_MOTOR_RELAY_PIN 16                                                  // V2: GPIO18 is shared with TP_INT and must not drive the grinder
+#else
+#define HW_MOTOR_RELAY_PIN 18                                                  // V1 grinder motor control relay
+#endif
 #define HW_GRINDER_SETTLING_TIME_MS 500                                        // Startup transient immunity (tune based on mechanical rigidity, 0 to disable)
 
 //------------------------------------------------------------------------------

--- a/src/config/hardware.h
+++ b/src/config/hardware.h
@@ -17,7 +17,15 @@
 #define HW_TOUCH_I2C_ADDRESS 0x38                                              // I2C address of FT3168 touch controller
 
 // Display Controller (QSPI)
-#define HW_DISPLAY_CS_PIN 9                                                    // SPI chip select for display controller
+#ifndef HW_DISPLAY_VARIANT_V2
+#define HW_DISPLAY_VARIANT_V2 0                                               // V1 remains the default hardware target
+#endif
+
+#if HW_DISPLAY_VARIANT_V2
+#define HW_DISPLAY_CS_PIN 46                                                   // V2 PCB chip select for SH8601 display controller
+#else
+#define HW_DISPLAY_CS_PIN 9                                                    // V1 PCB chip select for CO5300 display controller
+#endif
 #define HW_DISPLAY_SCK_PIN 10                                                  // SPI clock for display controller
 #define HW_DISPLAY_D0_PIN 11                                                   // SPI data line 0 (QSPI mode)
 #define HW_DISPLAY_D1_PIN 12                                                   // SPI data line 1 (QSPI mode)
@@ -48,11 +56,16 @@
 //------------------------------------------------------------------------------
 #define HW_DISPLAY_WIDTH_PX 280                                                // LCD width in pixels
 #define HW_DISPLAY_HEIGHT_PX 456                                               // LCD height in pixels
-#define HW_DISPLAY_OFFSET_X_PX 0                                               // X offset for display positioning
 #define HW_DISPLAY_ROTATION_DEG 0                                              // Display rotation angle
+#if HW_DISPLAY_VARIANT_V2
+#define HW_DISPLAY_OFFSET_X_PX 20                                              // SH8601 framebuffer column offset
+#define HW_DISPLAY_QSPI_FREQUENCY_HZ 40000000                                  // Waveshare V2 reference QSPI clock
+#else
+#define HW_DISPLAY_OFFSET_X_PX 0                                               // V1 display positioning offset
 #define HW_DISPLAY_IPS_INVERT_X 180                                            // IPS X-axis inversion setting
 #define HW_DISPLAY_IPS_INVERT_Y 24                                             // IPS Y-axis inversion setting
 #define HW_DISPLAY_COLOR_ORDER 20                                              // Color channel ordering
+#endif
 #define HW_DISPLAY_MINIMAL_BRIGHTNESS_PERCENT 15                               // Minimum brightness percentage (to avoid too dim to see)
 
 //------------------------------------------------------------------------------

--- a/src/hardware/display_manager.cpp
+++ b/src/hardware/display_manager.cpp
@@ -1,17 +1,85 @@
 #include "display_manager.h"
+#if HW_DISPLAY_VARIANT_V2
+#include "esp_lcd_sh8601.h"
+#endif
 #include "../config/constants.h"
 #include "../config/logging.h"
 #include <Arduino.h>
 #include <esp_heap_caps.h>
+#if HW_DISPLAY_VARIANT_V2
+#include <driver/spi_master.h>
+#else
 #include <algorithm>
 #include <cstring>
+#endif
 
 DisplayManager* g_display_manager = nullptr;
+
+#if HW_DISPLAY_VARIANT_V2
+namespace {
+constexpr spi_host_device_t kDisplaySpiHost = SPI2_HOST;
+
+static const uint8_t kCmdC4[] = {0x80};
+static const uint8_t kCmd35[] = {0x00};
+static const uint8_t kCmd53[] = {0x20};
+static const uint8_t kCmd63[] = {0xFF};
+static const uint8_t kBrightnessOff[] = {0x00};
+static const uint8_t kBrightnessFull[] = {0xFF};
+static const sh8601_lcd_init_cmd_t kV2InitCommands[] = {
+    {0x11, nullptr, 0, 80},
+    {0xC4, kCmdC4, sizeof(kCmdC4), 0},
+    {0x35, kCmd35, sizeof(kCmd35), 0},
+    {0x53, kCmd53, sizeof(kCmd53), 1},
+    {0x63, kCmd63, sizeof(kCmd63), 1},
+    {0x51, kBrightnessOff, sizeof(kBrightnessOff), 1},
+    {0x29, nullptr, 0, 10},
+    {0x51, kBrightnessFull, sizeof(kBrightnessFull), 0},
+};
+}
+#endif
 
 void DisplayManager::init() {
     g_display_manager = this;
     
-    // Initialize display hardware
+#if HW_DISPLAY_VARIANT_V2
+    // V2 uses an SH8601 panel and GPIO 46 for chip select. The native
+    // esp_lcd driver is required; the V1 Arduino_GFX path leaves V2 black.
+    spi_bus_config_t bus_config = SH8601_PANEL_BUS_QSPI_CONFIG(
+        HW_DISPLAY_SCK_PIN, HW_DISPLAY_D0_PIN, HW_DISPLAY_D1_PIN,
+        HW_DISPLAY_D2_PIN, HW_DISPLAY_D3_PIN,
+        HW_DISPLAY_WIDTH_PX * HW_DISPLAY_HEIGHT_PX * sizeof(uint16_t));
+    if (spi_bus_initialize(kDisplaySpiHost, &bus_config, SPI_DMA_CH_AUTO) != ESP_OK) {
+        return;
+    }
+
+    esp_lcd_panel_io_spi_config_t io_config =
+        SH8601_PANEL_IO_QSPI_CONFIG(HW_DISPLAY_CS_PIN, color_transfer_done_cb, this);
+    io_config.pclk_hz = HW_DISPLAY_QSPI_FREQUENCY_HZ;
+    if (esp_lcd_new_panel_io_spi(
+            static_cast<esp_lcd_spi_bus_handle_t>(kDisplaySpiHost),
+            &io_config, &panel_io) != ESP_OK) {
+        return;
+    }
+
+    sh8601_vendor_config_t vendor_config = {};
+    vendor_config.init_cmds = kV2InitCommands;
+    vendor_config.init_cmds_size = sizeof(kV2InitCommands) / sizeof(kV2InitCommands[0]);
+    vendor_config.flags.use_qspi_interface = 1;
+
+    esp_lcd_panel_dev_config_t panel_config = {};
+    panel_config.reset_gpio_num = HW_DISPLAY_RESET_PIN;
+    panel_config.rgb_ele_order = LCD_RGB_ELEMENT_ORDER_RGB;
+    panel_config.bits_per_pixel = 16;
+    panel_config.vendor_config = &vendor_config;
+
+    if (esp_lcd_new_panel_sh8601(panel_io, &panel_config, &panel_handle) != ESP_OK ||
+        esp_lcd_panel_reset(panel_handle) != ESP_OK ||
+        esp_lcd_panel_init(panel_handle) != ESP_OK ||
+        esp_lcd_panel_disp_on_off(panel_handle, true) != ESP_OK) {
+        return;
+    }
+#else
+    // Initialize V1 display hardware
     bus = new Arduino_ESP32QSPI(
         HW_DISPLAY_CS_PIN, HW_DISPLAY_SCK_PIN, HW_DISPLAY_D0_PIN, 
         HW_DISPLAY_D1_PIN, HW_DISPLAY_D2_PIN, HW_DISPLAY_D3_PIN);
@@ -26,17 +94,32 @@ void DisplayManager::init() {
     }
     
     gfx_device->fillScreen(RGB565_BLACK);
+#endif
     
     // Initialize LVGL
     lv_init();
     lv_tick_set_cb(millis_cb);
     
+#if HW_DISPLAY_VARIANT_V2
+    screen_width = HW_DISPLAY_WIDTH_PX;
+    screen_height = HW_DISPLAY_HEIGHT_PX;
+#else
     screen_width = gfx_device->width();
     screen_height = gfx_device->height();
+#endif
 
     // Full screen buffer, but only partial updates used
     // RGB565 format (16bit per pixel)
     draw_buffer = nullptr;
+#if HW_DISPLAY_VARIANT_V2
+    // Keep the DMA-capable buffer small enough to leave internal RAM for the UI
+    // FreeRTOS task. LVGL splits larger invalidated areas into strips.
+    const size_t draw_rows = 8; // 280 * 8 * 2 = 4,480 bytes
+    buffer_size = screen_width * draw_rows * sizeof(uint16_t);
+    draw_buffer = static_cast<lv_color_t*>(
+        heap_caps_aligned_alloc(LV_DRAW_BUF_ALIGN, buffer_size,
+                                MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT));
+#else
     dma_staging_buffer = nullptr;
     dma_staging_rows = 16;
 
@@ -54,12 +137,14 @@ void DisplayManager::init() {
                                     buffer_size,
                                     MALLOC_CAP_8BIT));
     }
+#endif
 
     if (!draw_buffer) {
         LOG_BLE("[DISPLAY] ERROR: Failed to allocate LVGL draw buffer\n");
         return;
     }
 
+#if !HW_DISPLAY_VARIANT_V2
     while (dma_staging_rows >= 4 && dma_staging_buffer == nullptr) {
         dma_staging_buffer = static_cast<uint16_t*>(
             heap_caps_aligned_alloc(LV_DRAW_BUF_ALIGN,
@@ -76,6 +161,7 @@ void DisplayManager::init() {
         draw_buffer = nullptr;
         return;
     }
+#endif
 
     lvgl_display = lv_display_create(screen_width, screen_height);
     lv_display_set_flush_cb(lvgl_display, display_flush_cb);
@@ -110,6 +196,23 @@ void DisplayManager::display_rounder_cb(lv_event_t* e) {
 }
 
 void DisplayManager::display_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
+#if HW_DISPLAY_VARIANT_V2
+    if (!g_display_manager || !g_display_manager->panel_handle) {
+        lv_display_flush_ready(disp);
+        return;
+    }
+
+    g_display_manager->pending_flush_display = disp;
+    esp_err_t result = esp_lcd_panel_draw_bitmap(
+        g_display_manager->panel_handle,
+        area->x1 + HW_DISPLAY_OFFSET_X_PX, area->y1,
+        area->x2 + HW_DISPLAY_OFFSET_X_PX + 1, area->y2 + 1,
+        px_map);
+    if (result != ESP_OK) {
+        g_display_manager->pending_flush_display = nullptr;
+        lv_display_flush_ready(disp);
+    }
+#else
     if (!g_display_manager || !g_display_manager->gfx_device) return;
     
     uint32_t w = lv_area_get_width(area);
@@ -149,7 +252,22 @@ void DisplayManager::display_flush_cb(lv_display_t* disp, const lv_area_t* area,
     }
     
     lv_display_flush_ready(disp);
+#endif
 }
+
+#if HW_DISPLAY_VARIANT_V2
+bool DisplayManager::color_transfer_done_cb(esp_lcd_panel_io_handle_t,
+                                            esp_lcd_panel_io_event_data_t*,
+                                            void* user_context) {
+    DisplayManager* manager = static_cast<DisplayManager*>(user_context);
+    if (manager && manager->pending_flush_display) {
+        lv_display_t* display = manager->pending_flush_display;
+        manager->pending_flush_display = nullptr;
+        lv_display_flush_ready(display);
+    }
+    return false;
+}
+#endif
 
 void DisplayManager::touchpad_read_cb(lv_indev_t* indev, lv_indev_data_t* data) {
     if (!g_display_manager) return;
@@ -170,14 +288,24 @@ uint32_t DisplayManager::millis_cb() {
 }
 
 void DisplayManager::set_brightness(float brightness) {
+#if HW_DISPLAY_VARIANT_V2
+    if (!initialized || !panel_io) return;
+#else
     if (!initialized || !gfx_device) return;
+#endif
     
     // Clamp brightness to valid hardware range [0.0, 1.0]
     if (brightness < 0.0f) brightness = 0.0f;
     if (brightness > 1.0f) brightness = 1.0f;
     
+    uint8_t brightness_value = (uint8_t)(brightness * 255.0f);
+#if HW_DISPLAY_VARIANT_V2
+    uint32_t brightness_command = (0x02UL << 24) | (0x51UL << 8);
+    esp_lcd_panel_io_tx_param(panel_io, brightness_command,
+                              &brightness_value, sizeof(brightness_value));
+#else
     // Cast to CO5300 and call setBrightness with 8-bit value
     Arduino_CO5300* display = static_cast<Arduino_CO5300*>(gfx_device);
-    uint8_t brightness_value = (uint8_t)(brightness * 255.0f);
     display->setBrightness(brightness_value);
+#endif
 }

--- a/src/hardware/display_manager.h
+++ b/src/hardware/display_manager.h
@@ -1,19 +1,35 @@
 #pragma once
+#include "../config/hardware.h"
+#if HW_DISPLAY_VARIANT_V2
+#include <esp_lcd_panel_io.h>
+#include <esp_lcd_panel_ops.h>
+#else
 #include <Arduino_GFX_Library.h>
+#endif
 #include <lvgl.h>
 #include "touch_driver.h"
 #include "../config/constants.h"
 
 class DisplayManager {
 private:
+#if HW_DISPLAY_VARIANT_V2
+    esp_lcd_panel_io_handle_t panel_io;
+    esp_lcd_panel_handle_t panel_handle;
+    lv_display_t* pending_flush_display;
+#else
     Arduino_DataBus* bus;
     Arduino_GFX* gfx_device;
+#endif
     lv_display_t* lvgl_display;
     lv_indev_t* lvgl_input;
     lv_color_t* draw_buffer;
+#if !HW_DISPLAY_VARIANT_V2
     uint16_t* dma_staging_buffer;
+#endif
     TouchDriver touch_driver;
+#if !HW_DISPLAY_VARIANT_V2
     uint16_t dma_staging_rows;
+#endif
     
     uint32_t screen_width;
     uint32_t screen_height;
@@ -32,6 +48,11 @@ public:
     
 private:
     static void display_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map);
+#if HW_DISPLAY_VARIANT_V2
+    static bool color_transfer_done_cb(esp_lcd_panel_io_handle_t panel_io,
+                                       esp_lcd_panel_io_event_data_t* event_data,
+                                       void* user_context);
+#endif
     static void display_rounder_cb(lv_event_t* e);
     static void touchpad_read_cb(lv_indev_t* indev, lv_indev_data_t* data);
     static uint32_t millis_cb();

--- a/src/hardware/esp_lcd_sh8601.c
+++ b/src/hardware/esp_lcd_sh8601.c
@@ -1,0 +1,346 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
+#include <stdlib.h>
+#include <sys/cdefs.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/gpio.h"
+#include "esp_check.h"
+#include "esp_lcd_panel_interface.h"
+#include "esp_lcd_panel_io.h"
+#include "esp_lcd_panel_vendor.h"
+#include "esp_lcd_panel_ops.h"
+#include "esp_lcd_panel_commands.h"
+#include "esp_log.h"
+
+#include "esp_lcd_sh8601.h"
+
+#define LCD_OPCODE_WRITE_CMD        (0x02ULL)
+#define LCD_OPCODE_READ_CMD         (0x03ULL)
+#define LCD_OPCODE_WRITE_COLOR      (0x32ULL)
+
+static const char *TAG = "sh8601";
+
+static esp_err_t panel_sh8601_del(esp_lcd_panel_t *panel);
+static esp_err_t panel_sh8601_reset(esp_lcd_panel_t *panel);
+static esp_err_t panel_sh8601_init(esp_lcd_panel_t *panel);
+static esp_err_t panel_sh8601_draw_bitmap(esp_lcd_panel_t *panel, int x_start, int y_start, int x_end, int y_end, const void *color_data);
+static esp_err_t panel_sh8601_invert_color(esp_lcd_panel_t *panel, bool invert_color_data);
+static esp_err_t panel_sh8601_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool mirror_y);
+static esp_err_t panel_sh8601_swap_xy(esp_lcd_panel_t *panel, bool swap_axes);
+static esp_err_t panel_sh8601_set_gap(esp_lcd_panel_t *panel, int x_gap, int y_gap);
+static esp_err_t panel_sh8601_disp_on_off(esp_lcd_panel_t *panel, bool off);
+
+typedef struct {
+    esp_lcd_panel_t base;
+    esp_lcd_panel_io_handle_t io;
+    int reset_gpio_num;
+    int x_gap;
+    int y_gap;
+    uint8_t fb_bits_per_pixel;
+    uint8_t madctl_val; // save current value of LCD_CMD_MADCTL register
+    uint8_t colmod_val; // save surrent value of LCD_CMD_COLMOD register
+    const sh8601_lcd_init_cmd_t *init_cmds;
+    uint16_t init_cmds_size;
+    struct {
+        unsigned int use_qspi_interface: 1;
+        unsigned int reset_level: 1;
+    } flags;
+} sh8601_panel_t;
+
+esp_err_t esp_lcd_new_panel_sh8601(const esp_lcd_panel_io_handle_t io, const esp_lcd_panel_dev_config_t *panel_dev_config, esp_lcd_panel_handle_t *ret_panel)
+{
+    ESP_RETURN_ON_FALSE(io && panel_dev_config && ret_panel, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+
+    esp_err_t ret = ESP_OK;
+    sh8601_panel_t *sh8601 = NULL;
+    sh8601 = calloc(1, sizeof(sh8601_panel_t));
+    ESP_GOTO_ON_FALSE(sh8601, ESP_ERR_NO_MEM, err, TAG, "no mem for sh8601 panel");
+
+    if (panel_dev_config->reset_gpio_num >= 0) {
+        gpio_config_t io_conf = {
+            .mode = GPIO_MODE_OUTPUT,
+            .pin_bit_mask = 1ULL << panel_dev_config->reset_gpio_num,
+        };
+        ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, TAG, "configure GPIO for RST line failed");
+    }
+
+    switch (panel_dev_config->rgb_ele_order) {
+    case LCD_RGB_ELEMENT_ORDER_RGB:
+        sh8601->madctl_val = 0;
+        break;
+    case LCD_RGB_ELEMENT_ORDER_BGR:
+        sh8601->madctl_val |= LCD_CMD_BGR_BIT;
+        break;
+    default:
+        ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported color element order");
+        break;
+    }
+
+    uint8_t fb_bits_per_pixel = 0;
+    switch (panel_dev_config->bits_per_pixel) {
+    case 16: // RGB565
+        sh8601->colmod_val = 0x55;
+        fb_bits_per_pixel = 16;
+        break;
+    case 18: // RGB666
+        sh8601->colmod_val = 0x66;
+        // each color component (R/G/B) should occupy the 6 high bits of a byte, which means 3 full bytes are required for a pixel
+        fb_bits_per_pixel = 18;
+        break;
+    case 24: // RGB888
+        sh8601->colmod_val = 0x77;
+        fb_bits_per_pixel = 24;
+        break;
+    default:
+        ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported pixel width");
+        break;
+    }
+
+    sh8601->io = io;
+    sh8601->reset_gpio_num = panel_dev_config->reset_gpio_num;
+    sh8601->fb_bits_per_pixel = fb_bits_per_pixel;
+    sh8601_vendor_config_t *vendor_config = (sh8601_vendor_config_t *)panel_dev_config->vendor_config;
+    if (vendor_config) {
+        sh8601->init_cmds = vendor_config->init_cmds;
+        sh8601->init_cmds_size = vendor_config->init_cmds_size;
+        sh8601->flags.use_qspi_interface = vendor_config->flags.use_qspi_interface;
+    }
+    sh8601->flags.reset_level = panel_dev_config->flags.reset_active_high;
+    sh8601->base.del = panel_sh8601_del;
+    sh8601->base.reset = panel_sh8601_reset;
+    sh8601->base.init = panel_sh8601_init;
+    sh8601->base.draw_bitmap = panel_sh8601_draw_bitmap;
+    sh8601->base.invert_color = panel_sh8601_invert_color;
+    sh8601->base.set_gap = panel_sh8601_set_gap;
+    sh8601->base.mirror = panel_sh8601_mirror;
+    sh8601->base.swap_xy = panel_sh8601_swap_xy;
+    sh8601->base.disp_on_off = panel_sh8601_disp_on_off;
+    *ret_panel = &(sh8601->base);
+    ESP_LOGD(TAG, "new sh8601 panel @%p", sh8601);
+
+    //ESP_LOGI(TAG, "LCD panel create success, version: %d.%d.%d", ESP_LCD_SH8601_VER_MAJOR, ESP_LCD_SH8601_VER_MINOR,
+             //ESP_LCD_SH8601_VER_PATCH);
+
+    return ESP_OK;
+
+err:
+    if (sh8601) {
+        if (panel_dev_config->reset_gpio_num >= 0) {
+            gpio_reset_pin(panel_dev_config->reset_gpio_num);
+        }
+        free(sh8601);
+    }
+    return ret;
+}
+
+static esp_err_t tx_param(sh8601_panel_t *sh8601, esp_lcd_panel_io_handle_t io, int lcd_cmd, const void *param, size_t param_size)
+{
+    if (sh8601->flags.use_qspi_interface) {
+        lcd_cmd &= 0xff;
+        lcd_cmd <<= 8;
+        lcd_cmd |= LCD_OPCODE_WRITE_CMD << 24;
+    }
+    return esp_lcd_panel_io_tx_param(io, lcd_cmd, param, param_size);
+}
+
+static esp_err_t tx_color(sh8601_panel_t *sh8601, esp_lcd_panel_io_handle_t io, int lcd_cmd, const void *param, size_t param_size)
+{
+    if (sh8601->flags.use_qspi_interface) {
+        lcd_cmd &= 0xff;
+        lcd_cmd <<= 8;
+        lcd_cmd |= LCD_OPCODE_WRITE_COLOR << 24;
+    }
+    return esp_lcd_panel_io_tx_color(io, lcd_cmd, param, param_size);
+}
+
+static esp_err_t panel_sh8601_del(esp_lcd_panel_t *panel)
+{
+    sh8601_panel_t *sh8601 = __containerof(panel, sh8601_panel_t, base);
+
+    if (sh8601->reset_gpio_num >= 0) {
+        gpio_reset_pin(sh8601->reset_gpio_num);
+    }
+    ESP_LOGD(TAG, "del sh8601 panel @%p", sh8601);
+    free(sh8601);
+    return ESP_OK;
+}
+
+static esp_err_t panel_sh8601_reset(esp_lcd_panel_t *panel)
+{
+    sh8601_panel_t *sh8601 = __containerof(panel, sh8601_panel_t, base);
+    esp_lcd_panel_io_handle_t io = sh8601->io;
+
+    // Perform hardware reset
+    if (sh8601->reset_gpio_num >= 0) {
+        gpio_set_level(sh8601->reset_gpio_num, sh8601->flags.reset_level);
+        vTaskDelay(pdMS_TO_TICKS(10));
+        gpio_set_level(sh8601->reset_gpio_num, !sh8601->flags.reset_level);
+        vTaskDelay(pdMS_TO_TICKS(150));
+    } else { // Perform software reset
+        ESP_RETURN_ON_ERROR(tx_param(sh8601, io, LCD_CMD_SWRESET, NULL, 0), TAG, "send command failed");
+        vTaskDelay(pdMS_TO_TICKS(80));
+    }
+
+    return ESP_OK;
+}
+
+static const sh8601_lcd_init_cmd_t vendor_specific_init_default[] = {
+//  {cmd, { data }, data_size, delay_ms}
+    {0x44, (uint8_t []){0x01, 0xD1}, 2, 0},
+    {0x35, (uint8_t []){0x00}, 0, 0},
+    {0x53, (uint8_t []){0x20}, 1, 25},
+};
+
+static esp_err_t panel_sh8601_init(esp_lcd_panel_t *panel)
+{
+    sh8601_panel_t *sh8601 = __containerof(panel, sh8601_panel_t, base);
+    esp_lcd_panel_io_handle_t io = sh8601->io;
+    const sh8601_lcd_init_cmd_t *init_cmds = NULL;
+    uint16_t init_cmds_size = 0;
+    bool is_cmd_overwritten = false;
+
+    ESP_RETURN_ON_ERROR(tx_param(sh8601, io, LCD_CMD_MADCTL, (uint8_t[]) {
+        sh8601->madctl_val,
+    }, 1), TAG, "send command failed");
+    ESP_RETURN_ON_ERROR(tx_param(sh8601, io, LCD_CMD_COLMOD, (uint8_t[]) {
+        sh8601->colmod_val,
+    }, 1), TAG, "send command failed");
+
+    // vendor specific initialization, it can be different between manufacturers
+    // should consult the LCD supplier for initialization sequence code
+    if (sh8601->init_cmds) {
+        init_cmds = sh8601->init_cmds;
+        init_cmds_size = sh8601->init_cmds_size;
+    } else {
+        init_cmds = vendor_specific_init_default;
+        init_cmds_size = sizeof(vendor_specific_init_default) / sizeof(sh8601_lcd_init_cmd_t);
+    }
+
+    for (int i = 0; i < init_cmds_size; i++) {
+        // Check if the command has been used or conflicts with the internal
+        switch (init_cmds[i].cmd) {
+        case LCD_CMD_MADCTL:
+            is_cmd_overwritten = true;
+            sh8601->madctl_val = ((uint8_t *)init_cmds[i].data)[0];
+            break;
+        case LCD_CMD_COLMOD:
+            is_cmd_overwritten = true;
+            sh8601->colmod_val = ((uint8_t *)init_cmds[i].data)[0];
+            break;
+        default:
+            is_cmd_overwritten = false;
+            break;
+        }
+
+        if (is_cmd_overwritten) {
+            ESP_LOGW(TAG, "The %02Xh command has been used and will be overwritten by external initialization sequence", init_cmds[i].cmd);
+        }
+
+        ESP_RETURN_ON_ERROR(tx_param(sh8601, io, init_cmds[i].cmd, init_cmds[i].data, init_cmds[i].data_bytes), TAG,
+                            "send command failed");
+        vTaskDelay(pdMS_TO_TICKS(init_cmds[i].delay_ms));
+    }
+    ESP_LOGD(TAG, "send init commands success");
+
+    return ESP_OK;
+}
+
+static esp_err_t panel_sh8601_draw_bitmap(esp_lcd_panel_t *panel, int x_start, int y_start, int x_end, int y_end, const void *color_data)
+{
+    sh8601_panel_t *sh8601 = __containerof(panel, sh8601_panel_t, base);
+    assert((x_start < x_end) && (y_start < y_end) && "start position must be smaller than end position");
+    esp_lcd_panel_io_handle_t io = sh8601->io;
+
+    x_start += sh8601->x_gap ;
+    x_end += sh8601->x_gap ;
+    y_start += sh8601->y_gap;
+    y_end += sh8601->y_gap;
+
+    // define an area of frame memory where MCU can access
+    ESP_RETURN_ON_ERROR(tx_param(sh8601, io, LCD_CMD_CASET, (uint8_t[]) {
+        (x_start >> 8) & 0xFF,
+        x_start & 0xFF,
+        ((x_end - 1) >> 8) & 0xFF,
+        (x_end - 1) & 0xFF,
+    }, 4), TAG, "send command failed");
+    ESP_RETURN_ON_ERROR(tx_param(sh8601, io, LCD_CMD_RASET, (uint8_t[]) {
+        (y_start >> 8) & 0xFF,
+        y_start & 0xFF,
+        ((y_end - 1) >> 8) & 0xFF,
+        (y_end - 1) & 0xFF,
+    }, 4), TAG, "send command failed");
+    // transfer frame buffer
+    size_t len = (x_end - x_start) * (y_end - y_start) * sh8601->fb_bits_per_pixel / 8;
+    tx_color(sh8601, io, LCD_CMD_RAMWR, color_data, len);
+
+    return ESP_OK;
+}
+
+static esp_err_t panel_sh8601_invert_color(esp_lcd_panel_t *panel, bool invert_color_data)
+{
+    sh8601_panel_t *sh8601 = __containerof(panel, sh8601_panel_t, base);
+    esp_lcd_panel_io_handle_t io = sh8601->io;
+    int command = 0;
+    if (invert_color_data) {
+        command = LCD_CMD_INVON;
+    } else {
+        command = LCD_CMD_INVOFF;
+    }
+    ESP_RETURN_ON_ERROR(tx_param(sh8601, io, command, NULL, 0), TAG, "send command failed");
+    return ESP_OK;
+}
+
+static esp_err_t panel_sh8601_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool mirror_y)
+{
+    sh8601_panel_t *sh8601 = __containerof(panel, sh8601_panel_t, base);
+    esp_lcd_panel_io_handle_t io = sh8601->io;
+    esp_err_t ret = ESP_OK;
+
+    if (mirror_x) {
+        sh8601->madctl_val |= BIT(6);
+    } else {
+        sh8601->madctl_val &= ~BIT(6);
+    }
+    if (mirror_y) {
+        ESP_LOGE(TAG, "mirror_y is not supported by this panel");
+        ret = ESP_ERR_NOT_SUPPORTED;
+    }
+    ESP_RETURN_ON_ERROR(tx_param(sh8601, io, LCD_CMD_MADCTL, (uint8_t[]) {
+        sh8601->madctl_val
+    }, 1), TAG, "send command failed");
+    return ret;
+}
+
+static esp_err_t panel_sh8601_swap_xy(esp_lcd_panel_t *panel, bool swap_axes)
+{
+    ESP_LOGE(TAG, "swap_xy is not supported by this panel");
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+static esp_err_t panel_sh8601_set_gap(esp_lcd_panel_t *panel, int x_gap, int y_gap)
+{
+    sh8601_panel_t *sh8601 = __containerof(panel, sh8601_panel_t, base);
+    sh8601->x_gap = x_gap;
+    sh8601->y_gap = y_gap;
+    return ESP_OK;
+}
+
+static esp_err_t panel_sh8601_disp_on_off(esp_lcd_panel_t *panel, bool on_off)
+{
+    sh8601_panel_t *sh8601 = __containerof(panel, sh8601_panel_t, base);
+    esp_lcd_panel_io_handle_t io = sh8601->io;
+    int command = 0;
+
+    if (on_off) {
+        command = LCD_CMD_DISPON;
+    } else {
+        command = LCD_CMD_DISPOFF;
+    }
+    ESP_RETURN_ON_ERROR(tx_param(sh8601, io, command, NULL, 0), TAG, "send command failed");
+    return ESP_OK;
+}

--- a/src/hardware/esp_lcd_sh8601.c
+++ b/src/hardware/esp_lcd_sh8601.c
@@ -276,9 +276,11 @@ static esp_err_t panel_sh8601_draw_bitmap(esp_lcd_panel_t *panel, int x_start, i
     }, 4), TAG, "send command failed");
     // transfer frame buffer
     size_t len = (x_end - x_start) * (y_end - y_start) * sh8601->fb_bits_per_pixel / 8;
-    tx_color(sh8601, io, LCD_CMD_RAMWR, color_data, len);
-
-    return ESP_OK;
+    // Propagate queue/transfer setup failures to the caller. The LVGL bridge
+    // marks a flush complete immediately on error; returning ESP_OK here when
+    // no transfer was queued would otherwise leave it waiting forever for a
+    // completion callback that can never arrive.
+    return tx_color(sh8601, io, LCD_CMD_RAMWR, color_data, len);
 }
 
 static esp_err_t panel_sh8601_invert_color(esp_lcd_panel_t *panel, bool invert_color_data)

--- a/src/hardware/esp_lcd_sh8601.h
+++ b/src/hardware/esp_lcd_sh8601.h
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+  */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "esp_lcd_panel_vendor.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief LCD panel initialization commands.
+ *
+ */
+typedef struct {
+    int cmd;                /*<! The specific LCD command */
+    const void *data;       /*<! Buffer that holds the command specific data */
+    size_t data_bytes;      /*<! Size of `data` in memory, in bytes */
+    unsigned int delay_ms;  /*<! Delay in milliseconds after this command */
+} sh8601_lcd_init_cmd_t;
+
+/**
+ * @brief LCD panel vendor configuration.
+ *
+ * @note  This structure can be used to select interface type and override default initialization commands.
+ * @note  This structure needs to be passed to the `vendor_config` field in `esp_lcd_panel_dev_config_t`.
+ *
+ */
+typedef struct {
+    const sh8601_lcd_init_cmd_t *init_cmds;    /*!< Pointer to initialization commands array.
+                                                 *  The array should be declared as `static const` and positioned outside the function.
+                                                 *  Please refer to `vendor_specific_init_default` in source file
+                                                 */
+    uint16_t init_cmds_size;    /*<! Number of commands in above array */
+    struct {
+        unsigned int use_qspi_interface: 1;     /*<! Set to 1 if use QSPI interface, default is SPI interface */
+    } flags;
+} sh8601_vendor_config_t;
+
+/**
+ * @brief Create LCD panel for model SH8601
+ *
+ * @param[in]  io LCD panel IO handle
+ * @param[in]  panel_dev_config General panel device configuration (Use `vendor_config` to select QSPI interface or override default initialization commands)
+ * @param[out] ret_panel Returned LCD panel handle
+ * @return
+ *      - ESP_OK: Success
+ *      - Otherwise: Fail
+ */
+esp_err_t esp_lcd_new_panel_sh8601(const esp_lcd_panel_io_handle_t io, const esp_lcd_panel_dev_config_t *panel_dev_config, esp_lcd_panel_handle_t *ret_panel);
+
+/**
+ * @brief LCD panel bus configuration structure
+ *
+ */
+#define SH8601_PANEL_BUS_SPI_CONFIG(sclk, mosi, max_trans_sz)   \
+    {                                                           \
+        .sclk_io_num = sclk,                                    \
+        .mosi_io_num = mosi,                                    \
+        .miso_io_num = -1,                                      \
+        .quadhd_io_num = -1,                                    \
+        .quadwp_io_num = -1,                                    \
+        .max_transfer_sz = max_trans_sz,                        \
+    }
+#define SH8601_PANEL_BUS_QSPI_CONFIG(sclk, d0, d1, d2, d3, max_trans_sz) \
+    {                                                           \
+        .data0_io_num = d0,                                     \
+        .data1_io_num = d1,                                     \
+        .sclk_io_num = sclk,                                    \
+        .data2_io_num = d2,                                     \
+        .data3_io_num = d3,                                     \
+        .max_transfer_sz = max_trans_sz,                        \
+    }
+
+/**
+ * @brief LCD panel IO configuration structure
+ *
+ */
+#define SH8601_PANEL_IO_SPI_CONFIG(cs, dc, cb, cb_ctx)          \
+    {                                                           \
+        .cs_gpio_num = cs,                                      \
+        .dc_gpio_num = dc,                                      \
+        .spi_mode = 0,                                          \
+        .pclk_hz = 40 * 1000 * 1000,                            \
+        .trans_queue_depth = 10,                                \
+        .on_color_trans_done = cb,                              \
+        .user_ctx = cb_ctx,                                     \
+        .lcd_cmd_bits = 8,                                      \
+        .lcd_param_bits = 8,                                    \
+    }
+#define SH8601_PANEL_IO_QSPI_CONFIG(cs, cb, cb_ctx)             \
+    {                                                           \
+        .cs_gpio_num = cs,                                      \
+        .dc_gpio_num = -1,                                      \
+        .spi_mode = 0,                                          \
+        .pclk_hz = 40 * 1000 * 1000,                            \
+        .trans_queue_depth = 10,                                \
+        .on_color_trans_done = cb,                              \
+        .user_ctx = cb_ctx,                                     \
+        .lcd_cmd_bits = 32,                                     \
+        .lcd_param_bits = 8,                                    \
+        .flags = {                                              \
+            .quad_mode = true,                                  \
+        },                                                      \
+    }
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary

- preserve the existing CO5300/Arduino_GFX implementation and V1 GPIO assignments as the default target
- add a separate `waveshare-esp32s3-touch-amoled-164-v2` target using Waveshare's native Espressif SH8601 QSPI driver
- configure the V2 display for GPIO 46 chip select, 40 MHz QSPI, and the 20-pixel X offset
- use the verified V2 external wiring: HX711 SCK on GPIO 1 and grinder motor control on GPIO 16
- document why V2 must not use GPIO 18 (`TP_INT`) and how to identify the correct Pin 3 motor lead
- build, package, and label separate V1/V2 release images and Web Flasher choices
- deploy Web Flasher updates when a release is published and remove the circular pre-deployment URL check

Fixes #144.

## Why

Waveshare's V2 revision is not compatible with the original board's display driver or all of its external GPIO assignments. V1 firmware can boot and expose diagnostics while leaving the V2 AMOLED completely black. GPIO 18 is also shared with the V2 touchscreen interrupt and its pull-up circuitry, which caused voltage leakage into the grinder control input.

The tested grinder also showed that the previously assumed trigger lead was wrong: Pin 3 was the grey motor-control lead and Pin 2 was the unused white lead. The documentation now treats plug position as authoritative because wire colours may vary between grinder revisions.

## Verified V2 configuration

- display: SH8601 via native `esp_lcd` QSPI driver
- display CS: GPIO 46
- HX711: DOUT GPIO 3, SCK GPIO 1
- grinder motor control: GPIO 16
- GPIO 18: reserved by touchscreen `TP_INT`; do not use for motor control
- verified Specialita wiring: grey Pin 3 to GPIO 16; white Pin 2 disconnected and insulated

## Validation

- existing V1 target build passed: `pio run -e waveshare-esp32s3-touch-amoled-164 -j4`
- V2 target build passed: `pio run -e waveshare-esp32s3-touch-amoled-164-v2 -j4`
- V2 native SH8601 display path confirmed on physical Waveshare SKU 31197
- complete V2 configuration installed on a grinder and used successfully over an extended period: display, touch, load cell, motor, and Bluetooth all working
- release and Web Flasher workflow YAML parses successfully
- `git diff --check` passes

## User impact

Source builders can select the correct V1/V2 target, and future releases will expose separately labelled V1 and V2 images in the Web Flasher. Existing V1 remains the default and keeps its original wiring.