### PR TITLE
Add Windows desktop simulator

### DIFF
--- a/.github/workflows/simulator.yml
+++ b/.github/workflows/simulator.yml
@@ -1,0 +1,29 @@
+name: Desktop simulator
+
+on:
+  pull_request:
+    paths:
+      - 'include/lv_conf.h'
+      - 'src/config/**'
+      - 'src/font/**'
+      - 'src/ui/**'
+      - 'sim/**'
+      - '.github/workflows/simulator.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'include/lv_conf.h'
+      - 'src/config/**'
+      - 'src/font/**'
+      - 'src/ui/**'
+      - 'sim/**'
+      - '.github/workflows/simulator.yml'
+
+jobs:
+  build-and-smoke-test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and test simulator
+        shell: pwsh
+        run: .\sim\build.ps1 -Test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .pio
 .vscode/
+sim/build/
 
 # Generated build info
 include/git_info.h

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -8,12 +8,15 @@ This guide is for developers who want to build the Smart Grind-by-Weight firmwar
 
 ## 🛠️ Development Setup
 
-### Prerequisites
+### Firmware prerequisites
 
 - **Python 3.8+** with pip
 - **Git** for version control
 - **USB cable** for initial firmware flashing
 - **Hardware** (ESP32-S3 board, HX711, load cell) for testing
+
+Hardware is not required for desktop UI and simulated grind-flow development;
+see [Desktop Simulator](#desktop-simulator).
 
 ### Initial Setup
 
@@ -32,7 +35,30 @@ This automatically creates a virtual environment and installs all required depen
 
 ---
 
-## 🔧 Build Targets
+## 🖥️ Desktop Simulator
+
+On Windows, the native simulator runs the production LVGL Ready and Grinding
+screens at the real display resolution, with mouse input and a deterministic
+grinder/load-cell scenario. It requires Visual Studio 2022 with the Desktop
+development with C++ workload, but no ESP32, display, load cell, PlatformIO, or
+SDL installation.
+
+```powershell
+.\sim\run.ps1
+```
+
+Run its automated UI/grind smoke scenario with:
+
+```powershell
+.\sim\build.ps1 -Test
+```
+
+See [sim/README.md](../sim/README.md) for controls, capabilities, and the
+hardware-validation boundary.
+
+---
+
+## 🔧 Firmware Build Targets
 
 The project has three build targets:
 

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -28,7 +28,11 @@
 
 /** Color depth: 1 (I1), 8 (L8), 16 (RGB565), 24 (RGB888), 32 (XRGB8888) */
 #define LV_COLOR_DEPTH 16
+#ifdef SMART_GRIND_SIM
+#define LV_COLOR_16_SWAP 0
+#else
 #define LV_COLOR_16_SWAP 1
+#endif
 /*=========================
    STDLIB WRAPPER SETTINGS
  *=========================*/
@@ -107,7 +111,11 @@
  * - LV_OS_MQX
  * - LV_OS_SDL2
  * - LV_OS_CUSTOM */
+#ifdef SMART_GRIND_SIM
+#define LV_USE_OS   LV_OS_WINDOWS
+#else
 #define LV_USE_OS   LV_OS_NONE
+#endif
 
 #if LV_USE_OS == LV_OS_CUSTOM
     #define LV_OS_CUSTOM_INCLUDE <stdint.h>
@@ -1296,7 +1304,11 @@
 #endif
 
 /** LVGL Windows backend */
+#ifdef SMART_GRIND_SIM
+#define LV_USE_WINDOWS    1
+#else
 #define LV_USE_WINDOWS    0
+#endif
 
 /** LVGL UEFI backend */
 #define LV_USE_UEFI 0

--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.24)
+project(smart_grind_simulator LANGUAGES C CXX)
+
+include(FetchContent)
+include(CTest)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 11)
+
+get_filename_component(PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+
+FetchContent_Declare(
+    lvgl
+    GIT_REPOSITORY https://github.com/lvgl/lvgl.git
+    GIT_TAG v9.3.0
+    GIT_SHALLOW TRUE
+)
+set(CONFIG_LV_BUILD_DEMOS OFF CACHE BOOL "" FORCE)
+set(CONFIG_LV_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(CONFIG_LV_USE_THORVG_INTERNAL OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(lvgl)
+
+target_compile_definitions(lvgl PUBLIC
+    SMART_GRIND_SIM
+)
+target_include_directories(lvgl PUBLIC "${PROJECT_ROOT}/include")
+
+add_executable(smart-grind-sim
+    main.cpp
+    grind_mode_format.cpp
+    "${PROJECT_ROOT}/src/ui/ui_helpers.cpp"
+    "${PROJECT_ROOT}/src/ui/screens/ready_screen.cpp"
+    "${PROJECT_ROOT}/src/ui/screens/grinding_screen_arc.cpp"
+    "${PROJECT_ROOT}/src/ui/screens/grinding_screen_chart.cpp"
+    "${PROJECT_ROOT}/src/font/lv_font_montserrat_56.c"
+    "${PROJECT_ROOT}/src/font/lv_font_montserrat_60.c"
+)
+
+target_compile_definitions(smart-grind-sim PRIVATE
+    SMART_GRIND_SIM
+    NOMINMAX
+)
+target_include_directories(smart-grind-sim PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/platform"
+    "${PROJECT_ROOT}/src"
+    "${PROJECT_ROOT}/include"
+    "${lvgl_SOURCE_DIR}/src"
+)
+target_link_libraries(smart-grind-sim PRIVATE lvgl user32 gdi32 shell32)
+
+if(MSVC)
+    target_compile_options(smart-grind-sim PRIVATE /W4 /permissive-)
+endif()
+
+if(BUILD_TESTING)
+    add_test(NAME simulator_smoke COMMAND smart-grind-sim --smoke)
+    set_tests_properties(simulator_smoke PROPERTIES TIMEOUT 15)
+endif()

--- a/sim/README.md
+++ b/sim/README.md
@@ -1,0 +1,65 @@
+# Desktop simulator
+
+The desktop simulator runs the Smart Grind-by-Weight LVGL interface in a native
+Windows window. It is intended for fast UI and grind-flow development without
+flashing or connecting a development board.
+
+The simulated panel has the same 280 x 456 logical resolution as the Waveshare
+display. It currently runs the production Ready screen, both production
+Grinding screen layouts, and the production Play/Stop/Complete control. A
+deterministic grinder/load-cell model supplies rising weight, changing flow,
+motor run-on, settling, and completion data.
+
+## Requirements
+
+- Windows 10 or later
+- Visual Studio 2022 with the Desktop development with C++ workload
+- Git and internet access for the first build (CMake fetches LVGL 9.3.0)
+
+No ESP32, display, load cell, grinder, PlatformIO, or SDL installation is
+required.
+
+## Run
+
+From PowerShell at the repository root:
+
+```powershell
+.\sim\run.ps1
+```
+
+The first run downloads LVGL and builds the executable. Later runs reuse the
+local build.
+
+Use the on-screen circular button to start, stop, acknowledge, and restart the
+grind flow. The desktop-only keyboard shortcuts are kept outside the simulated
+panel UI:
+
+- `V`: switch between the production arc and chart grinding layouts
+- `T`: tare the simulated load cell
+
+## Automated smoke test
+
+```powershell
+.\sim\build.ps1 -Test
+```
+
+The smoke scenario creates the production UI, starts a grind, verifies that the
+screen transitions to Grinding, and confirms that simulated load-cell weight
+advances.
+
+The simulator does not execute built ESP32 `.bin` files; those contain Xtensa
+machine code and cannot run in a native Windows process. The complete
+compatibility gate is therefore:
+
+1. Build the V1 firmware target.
+2. Build the V2 firmware target.
+3. Build and run this simulator smoke test against the shared production UI
+   source.
+
+## Scope and hardware boundary
+
+The simulator is suitable for UI layout, interaction flows, deterministic grind
+scenarios, and future web/BLE integration work. Physical hardware remains the
+authority for AMOLED initialization, QSPI/DMA timing, real touch-controller
+behaviour, ESP32 memory pressure, BLE/Wi-Fi coexistence, relay wiring, HX711
+electrical noise, and final motor safety checks.

--- a/sim/build.ps1
+++ b/sim/build.ps1
@@ -1,0 +1,34 @@
+param(
+    [switch]$Test
+)
+
+$ErrorActionPreference = 'Stop'
+$buildDirectory = Join-Path $PSScriptRoot 'build'
+
+$cmakeCommand = Get-Command cmake -ErrorAction SilentlyContinue
+if ($cmakeCommand) {
+    $cmake = $cmakeCommand.Source
+} else {
+    $candidates = @(
+        'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe',
+        'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe'
+    )
+    $cmake = $candidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+}
+
+if (-not $cmake) {
+    throw 'CMake was not found. Install the Visual Studio 2022 Desktop development with C++ workload.'
+}
+
+& $cmake -S $PSScriptRoot -B $buildDirectory -G 'Visual Studio 17 2022' -A x64
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+& $cmake --build $buildDirectory --config Release --target smart-grind-sim --parallel
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+if ($Test) {
+    & $cmake --build $buildDirectory --config Release --target RUN_TESTS
+    exit $LASTEXITCODE
+}
+
+Write-Host "Simulator built: $buildDirectory\Release\smart-grind-sim.exe"

--- a/sim/grind_mode_format.cpp
+++ b/sim/grind_mode_format.cpp
@@ -1,0 +1,16 @@
+#include "controllers/grind_mode_traits.h"
+
+#include "config/constants.h"
+#include <cstdio>
+
+void format_ready_value(char* buffer, std::size_t buffer_len, GrindMode mode, float value) {
+    if (!buffer || buffer_len == 0) {
+        return;
+    }
+
+    if (mode == GrindMode::TIME) {
+        std::snprintf(buffer, buffer_len, "%.1fs", value);
+    } else {
+        std::snprintf(buffer, buffer_len, SYS_WEIGHT_DISPLAY_FORMAT, value);
+    }
+}

--- a/sim/lv_conf.h
+++ b/sim/lv_conf.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// LVGL's desktop CMake support looks for lv_conf.h beside this CMake project
+// during a clean configure. Keep the firmware configuration authoritative and
+// only forward to it here; SMART_GRIND_SIM selects the Windows-specific paths.
+#include "../include/lv_conf.h"

--- a/sim/main.cpp
+++ b/sim/main.cpp
@@ -1,0 +1,295 @@
+#include <lvgl.h>
+#include <src/drivers/windows/lv_windows_display.h>
+
+#include "config/constants.h"
+#include "ui/screens/grinding_screen_arc.h"
+#include "ui/screens/grinding_screen_chart.h"
+#include "ui/screens/ready_screen.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <windows.h>
+
+namespace {
+
+constexpr int kDisplayWidth = 280;
+constexpr int kDisplayHeight = 456;
+constexpr float kTargetWeight = USER_SINGLE_ESPRESSO_WEIGHT_G;
+
+ReadyScreen ready_screen;
+GrindingScreenArc arc_screen;
+GrindingScreenChart chart_screen;
+lv_obj_t* grind_button = nullptr;
+lv_obj_t* grind_icon = nullptr;
+lv_obj_t* pulse_button = nullptr;
+bool chart_layout = false;
+bool grinding = false;
+bool settling = false;
+float weight_g = 0.0f;
+float flow_gps = 0.0f;
+uint32_t grind_started_ms = 0;
+uint32_t last_update_ms = 0;
+HWND simulator_window = nullptr;
+
+uint32_t now_ms() {
+    return static_cast<uint32_t>(GetTickCount64());
+}
+
+void set_status(const char* status) {
+    if (simulator_window) {
+        wchar_t title[160];
+        swprintf_s(title, L"Smart Grind Simulator - %S  [V: view, T: tare]", status);
+        SetWindowTextW(simulator_window, title);
+    }
+}
+
+void set_grind_button(const char* symbol, uint32_t color) {
+    if (grind_icon) {
+        lv_image_set_src(grind_icon, symbol);
+    }
+    if (grind_button) {
+        lv_obj_set_style_bg_color(grind_button, lv_color_hex(color), 0);
+    }
+}
+
+void show_ready() {
+    grinding = false;
+    settling = false;
+    arc_screen.hide();
+    chart_screen.hide();
+    ready_screen.show();
+    set_grind_button(LV_SYMBOL_PLAY, THEME_COLOR_PRIMARY);
+    set_status("READY");
+}
+
+void show_active_grind_screen() {
+    ready_screen.hide();
+    if (chart_layout) {
+        arc_screen.hide();
+        chart_screen.show();
+    } else {
+        chart_screen.hide();
+        arc_screen.show();
+    }
+}
+
+void reset_grind_views() {
+    arc_screen.update_profile_name("SINGLE");
+    chart_screen.update_profile_name("SINGLE");
+    arc_screen.update_target_weight(kTargetWeight);
+    chart_screen.update_target_weight(kTargetWeight);
+    arc_screen.update_current_weight(0.0f);
+    chart_screen.update_current_weight(0.0f);
+    arc_screen.update_progress(0);
+    chart_screen.reset_chart_data();
+}
+
+void start_grind() {
+    weight_g = 0.0f;
+    flow_gps = 0.0f;
+    grinding = true;
+    settling = false;
+    grind_started_ms = now_ms();
+    last_update_ms = grind_started_ms;
+    reset_grind_views();
+    show_active_grind_screen();
+    set_grind_button(LV_SYMBOL_STOP, THEME_COLOR_PRIMARY);
+    set_status("GRINDING");
+}
+
+void toggle_layout() {
+    chart_layout = !chart_layout;
+    if (!ready_screen.is_visible()) {
+        show_active_grind_screen();
+    }
+    set_status(chart_layout ? "CHART VIEW" : "ARC VIEW");
+}
+
+void tare() {
+    weight_g = 0.0f;
+    arc_screen.update_tare_display();
+    chart_screen.update_tare_display();
+    set_status("TARE");
+}
+
+void grind_button_event(lv_event_t*) {
+    if (ready_screen.is_visible()) {
+        start_grind();
+    } else if (grinding || settling) {
+        grinding = false;
+        settling = false;
+        set_grind_button(LV_SYMBOL_OK, THEME_COLOR_SUCCESS);
+        set_status("STOPPED");
+    } else {
+        show_ready();
+    }
+}
+
+void create_grinder_controls() {
+    grind_button = lv_button_create(lv_screen_active());
+    lv_obj_set_size(grind_button, 100, 100);
+    lv_obj_align(grind_button, LV_ALIGN_BOTTOM_MID, 0, -10);
+    lv_obj_set_style_radius(grind_button, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_bg_color(grind_button, lv_color_hex(THEME_COLOR_PRIMARY), 0);
+    lv_obj_set_style_border_width(grind_button, 0, 0);
+    lv_obj_set_style_shadow_width(grind_button, 0, 0);
+    lv_obj_add_event_cb(grind_button, grind_button_event, LV_EVENT_CLICKED, nullptr);
+
+    grind_icon = lv_image_create(grind_button);
+    lv_image_set_src(grind_icon, LV_SYMBOL_PLAY);
+    lv_obj_set_style_text_font(grind_icon, &lv_font_montserrat_24, 0);
+    lv_obj_center(grind_icon);
+
+    pulse_button = lv_button_create(lv_screen_active());
+    lv_obj_set_size(pulse_button, 100, 100);
+    lv_obj_align(pulse_button, LV_ALIGN_BOTTOM_MID, 60, -10);
+    lv_obj_set_style_radius(pulse_button, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_bg_color(pulse_button, lv_color_hex(THEME_COLOR_ACCENT), 0);
+    lv_obj_set_style_border_width(pulse_button, 0, 0);
+    lv_obj_set_style_shadow_width(pulse_button, 0, 0);
+    lv_obj_add_flag(pulse_button, LV_OBJ_FLAG_HIDDEN);
+
+    lv_obj_t* pulse_icon = lv_image_create(pulse_button);
+    lv_image_set_src(pulse_icon, LV_SYMBOL_PLUS);
+    lv_obj_set_style_text_font(pulse_icon, &lv_font_montserrat_32, 0);
+    lv_obj_center(pulse_icon);
+}
+
+void update_mock_grind() {
+    if (!grinding && !settling) {
+        return;
+    }
+
+    const uint32_t current_ms = now_ms();
+    const float dt_s = std::min(0.1f, static_cast<float>(current_ms - last_update_ms) / 1000.0f);
+    last_update_ms = current_ms;
+    const float elapsed_s = static_cast<float>(current_ms - grind_started_ms) / 1000.0f;
+
+    if (grinding) {
+        flow_gps = std::min(1.75f, 0.25f + elapsed_s * 0.55f);
+        weight_g += flow_gps * dt_s;
+        if (weight_g >= kTargetWeight - 0.45f) {
+            grinding = false;
+            settling = true;
+            set_status("SETTLING");
+        }
+    } else if (settling) {
+        flow_gps *= std::pow(0.12f, dt_s);
+        weight_g += flow_gps * dt_s;
+        if (flow_gps < 0.015f) {
+            settling = false;
+            flow_gps = 0.0f;
+            set_grind_button(LV_SYMBOL_OK, THEME_COLOR_SUCCESS);
+            set_status("COMPLETE");
+        }
+    }
+
+    const int progress = std::clamp(static_cast<int>((weight_g / kTargetWeight) * 100.0f), 0, 100);
+    arc_screen.update_current_weight(weight_g);
+    chart_screen.update_current_weight(weight_g);
+    arc_screen.update_progress(progress);
+    chart_screen.add_chart_data_point(weight_g, flow_gps, current_ms);
+}
+
+bool has_arg(int argc, char** argv, const char* expected) {
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], expected) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    const bool smoke_test = has_arg(argc, argv, "--smoke");
+
+    if (smoke_test) {
+        std::puts("[smoke] starting simulator");
+        std::fflush(stdout);
+    }
+
+    lv_init();
+    lv_tick_set_cb(now_ms);
+
+    lv_display_t* display = lv_windows_create_display(
+        L"Smart Grind-by-Weight Simulator",
+        kDisplayWidth,
+        kDisplayHeight,
+        140,
+        true,
+        true);
+    if (!display) {
+        std::fprintf(stderr, "Could not create the simulator display.\n");
+        return 1;
+    }
+
+    simulator_window = lv_windows_get_display_window_handle(display);
+
+    // The Windows driver creates its framebuffer on the first LVGL timer pass.
+    // Let that happen before sizing and styling the production screen objects.
+    Sleep(LV_DEF_REFR_PERIOD + 1);
+    lv_timer_handler();
+
+    lv_obj_set_style_bg_color(lv_screen_active(), lv_color_hex(THEME_COLOR_BACKGROUND), 0);
+    lv_obj_set_style_bg_opa(lv_screen_active(), LV_OPA_COVER, 0);
+
+    ready_screen.create();
+    arc_screen.create();
+    chart_screen.create();
+    create_grinder_controls();
+    show_ready();
+    lv_obj_invalidate(lv_screen_active());
+    lv_refr_now(display);
+
+    if (smoke_test) {
+        std::puts("[smoke] UI created");
+        std::fflush(stdout);
+    }
+
+    HWND window = simulator_window;
+    const uint32_t smoke_started_ms = now_ms();
+    bool smoke_scenario_started = false;
+    bool view_key_down = false;
+    bool tare_key_down = false;
+
+    while (IsWindow(window)) {
+        if (smoke_test && !smoke_scenario_started && now_ms() - smoke_started_ms > 100) {
+            start_grind();
+            smoke_scenario_started = true;
+        }
+
+        update_mock_grind();
+
+        const bool view_pressed = (GetAsyncKeyState('V') & 0x8000) != 0;
+        if (view_pressed && !view_key_down) {
+            toggle_layout();
+        }
+        view_key_down = view_pressed;
+
+        const bool tare_pressed = (GetAsyncKeyState('T') & 0x8000) != 0;
+        if (tare_pressed && !tare_key_down) {
+            tare();
+        }
+        tare_key_down = tare_pressed;
+        const uint32_t wait_ms = std::clamp<uint32_t>(lv_timer_handler(), 1, 16);
+        Sleep(wait_ms);
+
+        if (smoke_test && now_ms() - smoke_started_ms > 750) {
+            if (!arc_screen.is_visible() || ready_screen.is_visible() || weight_g <= 0.0f) {
+                std::fprintf(stderr, "Simulator scenario did not advance.\n");
+                std::fflush(stderr);
+                ExitProcess(2);
+            }
+            std::printf("[smoke] scenario advanced to %.2fg\n", weight_g);
+            std::fflush(stdout);
+            ExitProcess(0);
+        }
+    }
+
+    lv_deinit();
+    return 0;
+}

--- a/sim/platform/Arduino.h
+++ b/sim/platform/Arduino.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// UI source files include Arduino.h for the device build, but the screen
+// classes used by the desktop simulator only require the standard C runtime.
+#include <cstdint>
+#include <cstdio>
+#include <chrono>
+
+inline unsigned long millis() {
+    using namespace std::chrono;
+    return static_cast<unsigned long>(
+        duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count());
+}
+
+struct SimulatorSerial {
+    void println(const char* message) const {
+        std::puts(message);
+    }
+
+    template <typename... Args>
+    void printf(const char* format, Args... args) const {
+        std::printf(format, args...);
+    }
+};
+
+inline SimulatorSerial Serial;

--- a/sim/run.ps1
+++ b/sim/run.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Stop'
+
+& (Join-Path $PSScriptRoot 'build.ps1')
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+$executable = Join-Path $PSScriptRoot 'build\Release\smart-grind-sim.exe'
+& $executable

--- a/src/config/build_info.h
+++ b/src/config/build_info.h
@@ -1,7 +1,14 @@
 #pragma once
 
 #include <cstdio>
+
+#ifdef SMART_GRIND_SIM
+#define BUILD_NUMBER 0
+#define GIT_COMMIT_ID "desktop-simulator"
+#define GIT_BRANCH "desktop-simulator"
+#else
 #include "../../include/git_info.h"
+#endif
 
 // Build information - BUILD_FIRMWARE_VERSION is automatically updated by release scripts
 #define BUILD_FIRMWARE_VERSION "1.4.0"                                          // Firmware version string (updated by release automation)


### PR DESCRIPTION
## What changed

- adds a native Windows LVGL simulator at the real 280 x 456 display resolution
- reuses the production Ready, arc-grinding, and chart-grinding screen implementations and fonts
- provides a deterministic grinder/load-cell scenario with weight, flow, motor run-on, settling, and completion
- adds mouse interaction, view/tare keyboard shortcuts, PowerShell build/run helpers, documentation, and a Windows CI smoke test

## Why

UI and grind-flow work currently requires repeated ESP32 flashing and access to a connected grinder. This gives contributors a fast desktop development loop while retaining explicit hardware validation boundaries.

## Validation

- `./sim/build.ps1 -Test` passes on the V1/main source tree
- simulator commit applies cleanly on top of V2 PR #145 and its smoke test passes
- V1 firmware target builds successfully
- V2 firmware target builds successfully
- complete diff reviewed; fixed a profile transition mismatch and a clean-configure LVGL header issue before publication

## Hardware boundary

The simulator does not execute ESP32 `.bin` files and does not replace testing AMOLED initialization, QSPI/DMA, physical touch, ESP32 memory pressure, BLE/Wi-Fi coexistence, relay wiring, HX711 electrical noise, or final motor safety.